### PR TITLE
Add LibreCores CI page and mentions to the Website

### DIFF
--- a/site/sitecontent/about.md
+++ b/site/sitecontent/about.md
@@ -25,12 +25,18 @@ At the moment, LibreCores is in a preview state.
 We've laid down much of the groundwork for the site, and are now able to iterate quickly on new ideas and features.
 We do this to enable everybody to get involved and shape the future of LibreCores with the goal of making it a place where the community can truly feel at home.
 
-Looking ahead in addition to many smaller improvements we want to focus on three major areas.
+Looking ahead in addition to many smaller improvements we want to focus on four major areas.
 
 - **Project quality metrics.** Sometimes it's hard to decide if a project is usable for a given project. To make the decision process easier, we are thinking about both user-generated quality metrics (such as comments or reviews, likes, etc.) as well as machine-generated metrics (e.g. activity metrics or build and test status from continuous integration).
 - **Workflow integration.** Finding an IP core on LibreCores is just the first step of using it as part of an own project. Currently, making use of a core  involves in many cases copying the source code into the custom project. This process is tedious and makes updating a core to the latest upstream version hard.
 
   With LibreCores we want to explore different options to make this workflow more streamlined. One example is the integration of the LibreCores project repository with the [fusesoc](https://github.com/olofk/fusesoc) package manager.
+- **LibreCores CI.** ContinuousIntegration of projects is a de-facto standard approach to improving project quality and contributor experience.
+There are many services providing free CI hosting for open-source software projects,
+but they lack some features required for hardware projects (EDA tools, running tests on hardware, etc.).
+
+  In LibreCores we want to provide a CI instance for projects being hosted on LibreCores.
+  More information is available on the [LibreCores CI page](./librecores-ci).
 - **Documentation of best practices.** At LibreCores, we love digital hardware design and want more people to get involved. Unfortunately today, getting started with digital hardware design involves climbing a steep learning curve before the one reaches productivity -- and arguably that's where all the fun starts!
 
   We believe a good documentation of best practices, covering both non-code issues (such as "how to organize a repository", "what license options do I have"), as well as coding related advice (such as "how to code a FSM in Verilog") is essential to get started quickly and is therefore of great benefit to the community.

--- a/site/sitecontent/librecores-ci.md
+++ b/site/sitecontent/librecores-ci.md
@@ -1,0 +1,33 @@
+# LibreCores CI
+
+[LibreCores CI](https://ci.librecores.org/) is a service, 
+which provides Continuous Integration of projects being hosted on LibreCores.
+The objective of the service is to improve the contributor experience and to increase trust to projects by providing automated testing and health metrics of the projects.
+Currently the service is **under development**.
+
+With LibreCores CI you will be able to...
+
+* Build your projects using [FuseSoC](https://github.com/olofk/fusesoc) and open-source EDAs
+* Run simulation tests in the cloud
+* Run tests on FPGAs and custom peripherals using "bring your own" agents
+* Define custom build flows using [Jenkins Pipeline](https://jenkins.io/doc/book/pipeline/) 
+* Setup pull request builders and test reporters in order to improve the contributor experience
+
+The service is powered by [Jenkins](https://jenkins.io/index.html).
+More information about the project is available in [GitHub](https://github.com/librecores/librecores-ci/).
+
+## Current status
+
+The LibreCores CI instance is **under development** now.
+The short-term plan is to provide a generic framework for automation of the FuseSoC-based projects.
+
+Status overview from [ORCONF2016](http://orconf.org/):
+
+<script async class="speakerdeck-embed" data-id="51cda97e786f411abab92287754e486d" data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>
+
+In the case of any questions, please use bugtracker in [GitHub](https://github.com/librecores/librecores-ci/).
+
+## Become a beta-tester
+
+If you are interested to try LibreCores CI, please contact us via the 
+[dev@lists.librecores.org](https://lists.librecores.org/listinfo/dev) mailing list.


### PR DESCRIPTION
Fixes #79:
- [x] Add a LibreCores CI page
- [x] Mention LibreCores CI in About

CC @wallento I think it's too early to put LibreCores CI as a top-level entry in the menu bar, especially since the layout is not perfect for narrow screens (CC @eliaskousk). 