### PR TITLE
Project page: Add badges for projects being hosted on GitHub

### DIFF
--- a/site/src/Librecores/ProjectRepoBundle/Entity/Project.php
+++ b/site/src/Librecores/ProjectRepoBundle/Entity/Project.php
@@ -4,6 +4,7 @@ namespace Librecores\ProjectRepoBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Librecores\ProjectRepoBundle\Util\GitHubUtil;
 
 /**
  * A project
@@ -672,5 +673,15 @@ class Project
     public function getDateLastModified()
     {
         return $this->dateLastModified;
+    }
+    
+    /**
+     * Gets GitHub Helper for the specified URL.
+     *
+     * @return \GitHubUtil
+     */
+    public function getGitHubUtil($url)
+    {
+        return new GitHubUtil($url);
     }
 }

--- a/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/view.html.twig
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/view.html.twig
@@ -94,6 +94,26 @@
       <a href="{{ project.getIssueTracker()|escape('html_attr') }}">Issue Tracker</a>
       <br/>
       {% endif %}
+      
+      <div class="project-badges">
+        <!--Stars badge, which comes from the Source repo-->
+        {% set starsBadgeHelper = project.getGitHubUtil(project.getSourceRepo().getUrl()) %}
+        {% if starsBadgeHelper.isOnGitHub()  %}
+          <a href="https://github.com/{{ starsBadgeHelper.getGitHubPath() }}">
+            <img border="0" src="{{ starsBadgeHelper.getStarsBadgeImage() }}">
+          </a>
+          <a href="https://github.com/{{ starsBadgeHelper.getGitHubPath() }}">
+            <img border="0" src="{{ starsBadgeHelper.getOpenPRsBadgeImage() }}">
+          </a>
+        {% endif %}
+        <!--Issues badge, which comes from the Issue tracker link-->
+        {% set issuesBadgeHelper = project.getGitHubUtil(project.getIssueTracker()) %}
+        {% if issuesBadgeHelper.isOnGitHub()  %}
+          <a href="https://github.com/{{ issuesBadgeHelper.getGitHubPath() }}/issues">
+            <img border="0" src="{{ starsBadgeHelper.getIssuesBadgeImage() }}">
+          </a>
+        {% endif %}
+      </div>
     </p>
   </div>
 

--- a/site/src/Librecores/ProjectRepoBundle/Util/GitHubUtil.php
+++ b/site/src/Librecores/ProjectRepoBundle/Util/GitHubUtil.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Librecores\ProjectRepoBundle\Util;
+
+/**
+ * Helper class, which provides methods for operating with GitHub projects.
+ */
+class GitHubUtil {
+  
+  private $url;
+  
+  public function __construct($url) {
+    $this->url = $url;
+  }
+  
+  public function isOnGitHub()
+  {
+    if (strpos($this->url, 'github') !== false) {
+      return true;
+    }
+    return false;
+  }
+  
+  public function getStarsBadgeImage()
+  {
+    return 'https://img.shields.io/github/stars/' . $this->getGitHubPath($this->url) . '.svg';
+  }
+  
+  public function getIssuesBadgeImage()
+  {
+    return 'https://img.shields.io/github/issues/' . $this->getGitHubPath($this->url) . '.svg';
+  }
+  
+  public function getOpenPRsBadgeImage()
+  {
+    return 'https://img.shields.io/github/issues-pr/' . $this->getGitHubPath($this->url) . '.svg';
+  }
+  
+  public function getGitHubPath()
+  {
+    return $this->getBetween($this->url, 'github.com/','.git');
+  }
+  
+  private function getBetween($input, $start, $end)
+  {
+    $substr = substr($input, strlen($start)+strpos($input, $start), (strlen($input) - strpos($input, $end))*(-1));
+    return $substr;
+  }
+}


### PR DESCRIPTION
Addresses #80

The PR provides the following badges:

* Number of stars (if SourceRepo URL is GitHub)
* Number of open pull requests (if SourceRepo URL is GitHub)
* Number of open issues (if Issue Tracker URL is GitHub)

**Disclaimer**: The code below likely contains my first code lines in PHP ever. Will appreciate any reviews regarding making the code compliant with project standards.

Example:
<img width="1173" alt="screen shot 2016-12-18 at 18 01 45" src="https://cloud.githubusercontent.com/assets/3000480/21295051/b0c14698-c54c-11e6-9069-bec7d6e18cee.png">

CC @asb and @berndca 
