### PR TITLE
Project page: Add badges for projects being hosted on GitHub (NEW)

### DIFF
--- a/site/src/Librecores/ProjectRepoBundle/Controller/ProjectController.php
+++ b/site/src/Librecores/ProjectRepoBundle/Controller/ProjectController.php
@@ -120,9 +120,14 @@ class ProjectController extends Controller {
             return $response;
         }
 
+        // Get Github Util service and set the source repo and issue tracker urls
+        $githubUtil = $this->getGitHubUtil();
+        $githubUtil->setUrls($p->getSourceRepo()->getUrl(), $p->getIssueTracker());
+
         // the actual project page
         return $this->render('LibrecoresProjectRepoBundle:Project:view.html.twig',
-            array('project' => $p));
+            array('project'     => $p,
+                  'githubUtil'  => $githubUtil));
     }
 
     /**
@@ -180,5 +185,14 @@ class ProjectController extends Controller {
 
         return $this->render('LibrecoresProjectRepoBundle:Project:settings_team.html.twig',
             array('project' => $p));
+    }
+
+    /**
+     * Get GitHub Helper for the specified URL.
+     *
+     */
+    public function getGitHubUtil()
+    {
+        return $this->get('projectrepo.util.github');
     }
 }

--- a/site/src/Librecores/ProjectRepoBundle/Entity/Project.php
+++ b/site/src/Librecores/ProjectRepoBundle/Entity/Project.php
@@ -674,14 +674,4 @@ class Project
     {
         return $this->dateLastModified;
     }
-    
-    /**
-     * Gets GitHub Helper for the specified URL.
-     *
-     * @return \GitHubUtil
-     */
-    public function getGitHubUtil($url)
-    {
-        return new GitHubUtil($url);
-    }
 }

--- a/site/src/Librecores/ProjectRepoBundle/Entity/Project.php
+++ b/site/src/Librecores/ProjectRepoBundle/Entity/Project.php
@@ -4,6 +4,7 @@ namespace Librecores\ProjectRepoBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Librecores\ProjectRepoBundle\Util\GitHubUtil;
 
 /**
  * A project
@@ -672,5 +673,15 @@ class Project
     public function getDateLastModified()
     {
         return $this->dateLastModified;
+    }
+    
+    /**
+     * Gets GitHub Helper for the specified URL.
+     *
+     * @return \GitHubUtil
+     */
+    public function getGitHubUtil($url)
+    {
+        return new GitHubUtil($url);
     }
 }

--- a/site/src/Librecores/ProjectRepoBundle/Resources/config/services.yml
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/config/services.yml
@@ -1,6 +1,10 @@
 parameters:
     librecores_user_provider.class: Librecores\ProjectRepoBundle\Security\Core\User\FOSUBUserProvider
-    librecores_user_manager.class: Librecores\ProjectRepoBundle\Doctrine\UserManager
+    librecores_user_manager.class:  Librecores\ProjectRepoBundle\Doctrine\UserManager
+
+    projectrepo.util.github_url:  'https://github.com/'
+    projectrepo.util.shields_url: 'https://img.shields.io/github/'
+    projectrepo.util.shields_ext: 'svg'
 
 services:
     update_project_info_service:
@@ -47,7 +51,13 @@ services:
             - @router
         tags:
             - { name: validator.constraint_validator }
-            
+
+    projectrepo.util.github:
+        class: Librecores\ProjectRepoBundle\Util\GitHubUtil
+        arguments:
+            - '%projectrepo.util.github_url%'
+            - '%projectrepo.util.shields_url%'
+            - '%projectrepo.util.shields_ext%'
 
 #    librecores_project_repo.example:
 #        class: Librecores\ProjectRepoBundle\Example

--- a/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/view.html.twig
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/view.html.twig
@@ -97,20 +97,18 @@
       
       <div class="project-badges">
         <!--Stars badge, which comes from the Source repo-->
-        {% set starsBadgeHelper = project.getGitHubUtil(project.getSourceRepo().getUrl()) %}
-        {% if starsBadgeHelper.isOnGitHub()  %}
-          <a href="https://github.com/{{ starsBadgeHelper.getGitHubPath() }}">
-            <img border="0" src="{{ starsBadgeHelper.getStarsBadgeImage() }}">
+        {% if githubUtil.isSourceRepoOnGitHub() %}
+          <a href="{{ githubUtil.getSourceRepoUrl() }}">
+            <img border="0" src="{{ githubUtil.getStarsBadgeImage() }}">
           </a>
-          <a href="https://github.com/{{ starsBadgeHelper.getGitHubPath() }}">
-            <img border="0" src="{{ starsBadgeHelper.getOpenPRsBadgeImage() }}">
+          <a href="{{ githubUtil.getPullRequestsUrl() }}">
+            <img border="0" src="{{ githubUtil.getOpenPRsBadgeImage() }}">
           </a>
         {% endif %}
         <!--Issues badge, which comes from the Issue tracker link-->
-        {% set issuesBadgeHelper = project.getGitHubUtil(project.getIssueTracker()) %}
-        {% if issuesBadgeHelper.isOnGitHub()  %}
-          <a href="https://github.com/{{ issuesBadgeHelper.getGitHubPath() }}/issues">
-            <img border="0" src="{{ starsBadgeHelper.getIssuesBadgeImage() }}">
+        {% if githubUtil.isIssueTrackerOnGitHub() %}
+          <a href="{{ githubUtil.getIssueTrackerUrl() }}">
+            <img border="0" src="{{ githubUtil.getIssuesBadgeImage() }}">
           </a>
         {% endif %}
       </div>

--- a/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/view.html.twig
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/view.html.twig
@@ -94,6 +94,26 @@
       <a href="{{ project.getIssueTracker()|escape('html_attr') }}">Issue Tracker</a>
       <br/>
       {% endif %}
+      
+      <div class="project-badges">
+        <!--Stars badge, which comes from the Source repo-->
+        {% set starsBadgeHelper = project.getGitHubUtil(project.getSourceRepo().getUrl()) %}
+        {% if starsBadgeHelper.isOnGitHub()  %}
+          <a href="https://github.com/{{ starsBadgeHelper.getGitHubPath() }}">
+            <img border="0" src="{{ starsBadgeHelper.getStarsBadgeImage() }}">
+          </a>
+          <a href="https://github.com/{{ starsBadgeHelper.getGitHubPath() }}">
+            <img border="0" src="{{ starsBadgeHelper.getOpenPRsBadgeImage() }}">
+          </a>
+        {% endif %}
+        <!--Issues badge, which comes from the Issue tracker link-->
+        {% set issuesBadgeHelper = project.getGitHubUtil(project.getIssueTracker()) %}
+        {% if issuesBadgeHelper.isOnGitHub()  %}
+          <a href="https://github.com/{{ issuesBadgeHelper.getGitHubPath() }}/issues">
+            <img border="0" src="{{ starsBadgeHelper.getIssuesBadgeImage() }}">
+          </a>
+        {% endif %}
+      </div>
     </p>
   </div>
 

--- a/site/src/Librecores/ProjectRepoBundle/Util/GitHubUtil.php
+++ b/site/src/Librecores/ProjectRepoBundle/Util/GitHubUtil.php
@@ -3,47 +3,134 @@
 namespace Librecores\ProjectRepoBundle\Util;
 
 /**
- * Helper class, which provides methods for operating with GitHub projects.
+ * Helper utility service, which provides methods for operating with GitHub projects.
  */
-class GitHubUtil {
-  
-  private $url;
-  
-  public function __construct($url) {
-    $this->url = $url;
-  }
-  
-  public function isOnGitHub()
-  {
-    if (strpos($this->url, 'github') !== false) {
-      return true;
+
+class GitHubUtil
+{
+
+    private $githubUrl;
+    private $shieldsUrl;
+    private $shieldsExt;
+    private $sourceRepoUrl;
+    private $issueTrackerUrl;
+
+    public function __construct($githubUrl, $shieldsUrl, $shieldsExt)
+    {
+        $this->githubUrl       = $githubUrl;
+        $this->shieldsUrl      = $shieldsUrl;
+        $this->shieldsExt      = $shieldsExt;
+        $this->sourceRepoUrl   = null;
+        $this->issueTrackerUrl = null;
     }
-    return false;
-  }
-  
-  public function getStarsBadgeImage()
-  {
-    return 'https://img.shields.io/github/stars/' . $this->getGitHubPath($this->url) . '.svg';
-  }
-  
-  public function getIssuesBadgeImage()
-  {
-    return 'https://img.shields.io/github/issues/' . $this->getGitHubPath($this->url) . '.svg';
-  }
-  
-  public function getOpenPRsBadgeImage()
-  {
-    return 'https://img.shields.io/github/issues-pr/' . $this->getGitHubPath($this->url) . '.svg';
-  }
-  
-  public function getGitHubPath()
-  {
-    return $this->getBetween($this->url, 'github.com/','.git');
-  }
-  
-  private function getBetween($input, $start, $end)
-  {
-    $substr = substr($input, strlen($start)+strpos($input, $start), (strlen($input) - strpos($input, $end))*(-1));
-    return $substr;
-  }
+
+    public function setUrls($sourceRepoUrl, $issueTrackerUrl)
+    {
+        $this->setSourceRepoUrl($sourceRepoUrl);
+        $this->setIssueTrackerUrl($issueTrackerUrl);
+    }
+
+    public function getSourceRepoUrl()
+    {
+        return $this->sourceRepoUrl;
+    }
+
+    public function setSourceRepoUrl($sourceRepoUrl)
+    {
+        $this->sourceRepoUrl= $sourceRepoUrl;
+    }
+
+    public function getIssueTrackerUrl()
+    {
+        return $this->issueTrackerUrl;
+    }
+
+    public function setIssueTrackerUrl($issueTrackerUrl)
+    {
+        $this->issueTrackerUrl = $issueTrackerUrl;
+    }
+
+    public function getPullRequestsUrl()
+    {
+        if ($this->isSourceRepoOnGitHub())
+        {
+            return $this->githubUrl . $this->getGitHubPath($this->sourceRepoUrl) . '/pulls';
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public function isSourceRepoOnGitHub()
+    {
+        return (strpos($this->sourceRepoUrl, 'github') !== false);
+    }
+
+    public function isIssueTrackerOnGitHub()
+    {
+        return (strpos($this->issueTrackerUrl, 'github') !== false);
+    }
+
+    public function getStarsBadgeImage()
+    {
+        if ($this->isSourceRepoOnGitHub())
+        {
+            return $this->getShieldsUrl('stars') .
+                   $this->getGitHubPath($this->sourceRepoUrl) .
+                   $this->getShieldsExt();
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public function getOpenPRsBadgeImage()
+    {
+        if ($this->isSourceRepoOnGitHub())
+        {
+            return $this->getShieldsUrl('issues-pr') .
+                   $this->getGitHubPath($this->sourceRepoUrl) .
+                   $this->getShieldsExt();
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public function getIssuesBadgeImage()
+    {
+        if ($this->isSourceRepoOnGitHub())
+        {
+            return $this->getShieldsUrl('issues') .
+                   $this->getGitHubPath($this->sourceRepoUrl) .
+                   $this->getShieldsExt();
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private function getShieldsUrl($type)
+    {
+        return $this->shieldsUrl . $type . '/';
+    }
+
+    private function getShieldsExt()
+    {
+        return '.' . $this->shieldsExt;
+    }
+
+    private function getGitHubPath($url)
+    {
+        return $this->getBetween($url, $this->githubUrl, '.git');
+    }
+
+    private function getBetween($input, $start, $end)
+    {
+        return substr($input, strlen($start)+strpos($input, $start), (strlen($input) - strpos($input, $end))*(-1));
+    }
 }

--- a/site/src/Librecores/ProjectRepoBundle/Util/GitHubUtil.php
+++ b/site/src/Librecores/ProjectRepoBundle/Util/GitHubUtil.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Librecores\ProjectRepoBundle\Util;
+
+/**
+ * Helper class, which provides methods for operating with GitHub projects.
+ */
+class GitHubUtil {
+  
+  private $url;
+  
+  public function __construct($url) {
+    $this->url = $url;
+  }
+  
+  public function isOnGitHub()
+  {
+    if (strpos($this->url, 'github') !== false) {
+      return true;
+    }
+    return false;
+  }
+  
+  public function getStarsBadgeImage()
+  {
+    return 'https://img.shields.io/github/stars/' . $this->getGitHubPath($this->url) . '.svg';
+  }
+  
+  public function getIssuesBadgeImage()
+  {
+    return 'https://img.shields.io/github/issues/' . $this->getGitHubPath($this->url) . '.svg';
+  }
+  
+  public function getOpenPRsBadgeImage()
+  {
+    return 'https://img.shields.io/github/issues-pr/' . $this->getGitHubPath($this->url) . '.svg';
+  }
+  
+  public function getGitHubPath()
+  {
+    return $this->getBetween($this->url, 'github.com/','.git');
+  }
+  
+  private function getBetween($input, $start, $end)
+  {
+    $substr = substr($input, strlen($start)+strpos($input, $start), (strlen($input) - strpos($input, $end))*(-1));
+    return $substr;
+  }
+}

--- a/site/src/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidator.php
+++ b/site/src/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidator.php
@@ -42,6 +42,15 @@ class UserOrgNameValidator extends ConstraintValidator
                              'search', 'static', 'unassigned', 'user' ];
 
     /**
+     * Routes that are excluded from checking for a match in userOrgReserved()
+     * since they will always match regardless of the selected username and
+     * thus produce false positive violations on any selected username.
+     *
+     * @var string[]
+     */
+    const EXCLUDE_ROUTE_CHECK = [ 'librecores_project_repo_user_org_view' ];
+
+    /**
      * Regular expression checking for valid characters in an user or org name
      *
      * The name is first converted to lowercase before passing to this regex,
@@ -144,7 +153,17 @@ class UserOrgNameValidator extends ConstraintValidator
      */
     private function userOrOrgReserved($value)
     {
-        return (in_array($value, self::RESERVED_NAMES) ||
-                $this->router->match('/' . $value)['_route']);
+        if (in_array($value, self::RESERVED_NAMES)) {
+            return true;
+        }
+
+        /*
+         * Also check for valid top-level routes in case we forgot to exclude
+         * a route pattern in the RESERVED_NAMES array.
+         */
+
+        $route = $this->router->match('/' . $value)['_route'];
+
+        return ($route !== null && !in_array($route, self::EXCLUDE_ROUTE_CHECK));
     }
 }

--- a/site/src/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidator.php
+++ b/site/src/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidator.php
@@ -62,7 +62,25 @@ class UserOrgNameValidator extends ConstraintValidator
      */
     const VALID_NAME_REGEX = '/^[a-z][a-z0-9-]+$/';
 
-    /** @var Doctrine\Bundle\DoctrineBundle\Registry */
+    /**
+     * Check if the user name is unique.
+     * FOS User Bundle already does this check
+     * so this is not needed if using that bundle.
+     *
+     * @var bool
+     */
+    const CHECK_UNIQUE_USER = false;
+
+    /*
+     * Check if the organization name is unique.
+     *
+     * @var bool
+     */
+    const CHECK_UNIQUE_ORG  = true;
+
+    /**
+     * @var Doctrine\Bundle\DoctrineBundle\Registry
+     */
     private $orm;
 
     /**
@@ -125,23 +143,28 @@ class UserOrgNameValidator extends ConstraintValidator
         $name = strtolower($name);
         $em = $this->orm->getManager();
 
-        $q =  'SELECT COUNT(u.id) FROM LibrecoresProjectRepoBundle:User u '.
-              'WHERE u.usernameCanonical = :name';
-        $cnt_user = $em->createQuery($q)
-            ->setParameter('name', $name)
-            ->getSingleScalarResult();
-        if ($cnt_user != 0) {
-            return true;
+        if (self::CHECK_UNIQUE_USER) {
+
+            $q = 'SELECT COUNT(u.id) FROM LibrecoresProjectRepoBundle:User u ' .
+                'WHERE u.usernameCanonical = :name';
+            $cnt_user = $em->createQuery($q)
+                ->setParameter('name', $name)
+                ->getSingleScalarResult();
+            if ($cnt_user != 0) {
+                return true;
+            }
         }
 
-        $q =  'SELECT COUNT(o.id) '.
-              'FROM LibrecoresProjectRepoBundle:Organization o '.
-              'WHERE LOWER(o.name) = :name';
-        $cnt_org = $em->createQuery($q)
-            ->setParameter('name', $name)
-            ->getSingleScalarResult();
-        if ($cnt_org != 0) {
-            return true;
+        if (self::CHECK_UNIQUE_ORG) {
+            $q = 'SELECT COUNT(o.id) ' .
+                'FROM LibrecoresProjectRepoBundle:Organization o ' .
+                'WHERE LOWER(o.name) = :name';
+            $cnt_org = $em->createQuery($q)
+                ->setParameter('name', $name)
+                ->getSingleScalarResult();
+            if ($cnt_org != 0) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
Original PR #83 from @oleg-nenashev:

Addresses #80

The PR provides the following badges:

* Number of stars (if SourceRepo URL is GitHub)
* Number of open pull requests (if SourceRepo URL is GitHub)
* Number of open issues (if Issue Tracker URL is GitHub)

**Disclaimer**: The code below likely contains my first code lines in PHP ever. Will appreciate any reviews regarding making the code compliant with project standards.

Example:
<img width="1173" alt="screen shot 2016-12-18 at 18 01 45" src="https://cloud.githubusercontent.com/assets/3000480/21295051/b0c14698-c54c-11e6-9069-bec7d6e18cee.png">

CC @asb and @berndca 