### PR TITLE
Fix the FOS User Manager service

### DIFF
--- a/site/src/Librecores/ProjectRepoBundle/Resources/config/services.yml
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/config/services.yml
@@ -22,7 +22,7 @@ services:
 
     librecores_user_manager:
         class: Librecores\ProjectRepoBundle\Doctrine\UserManager
-        arguments: [@security.encoder_factory, @fos_user.util.username_canonicalizer, @fos_user.util.email_canonicalizer, @fos_user.object_manager, %fos_user.model.user.class%]
+        arguments: ['@fos_user.util.password_updater', '@fos_user.util.canonical_fields_updater', '@fos_user.object_manager', '%fos_user.model.user.class%']
 
     librecores_user_provider:
         class: "%librecores_user_provider.class%"


### PR DESCRIPTION
Its constructor signature has changed on the latest development version so our derived user manager service needs correct injection of needed services.