### PR TITLE
Remove PHP 7 PPA (ondrej/php)

### DIFF
--- a/ansible/roles/web/tasks/php.yml
+++ b/ansible/roles/web/tasks/php.yml
@@ -1,7 +1,10 @@
 ---
 # Install PHP for the web server
-- name: Add PHP ppa repository
-  apt_repository: repo='ppa:ondrej/php'
+
+#
+#- name: Add PHP ppa repository
+#  apt_repository: repo='ppa:ondrej/php'
+#
 
 - name: Install PHP FPM
   sudo: yes


### PR DESCRIPTION
This PPA breaks PHP 7 extensions. Using the PPA the system contains both PHP 7.0 and PHP 7.1 extensions and so the PHP 7.1 ones don't get loaded on the installed PHP 7.0 interpreter (e.g the XML / SimpleXML extension is missing on the FPM but not on the CLI).

You can reproduce the problem just by destroying and re-creating your local VM (or provisioning it, I haven't tried it though).

I suppose we can keep the PPA and move to PHP 7.1 which is already released and seems pretty stable. If we stay on PHP 7.0 though we must remove the PPA.