### PR TITLE
Add error pages

### DIFF
--- a/site/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/site/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -1,0 +1,26 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}{{ status_code }} {{ status_text }}{% endblock %}
+
+{% block body %}
+  <div class="container">
+    <h1>{% block error_title %}We could not process your request{% endblock %}</h1>
+    <h2>{% block error_description %}The server returned "{{ status_code }} {{ status_text }}". That's all we know.{% endblock %}</h2>
+    <div class="row">
+      <div class="col-md-12">
+        {% block error_explanation %}
+          <p>
+            Please <a href="https://github.com/librecores/librecores-web/issues">open an issue</a> at our Github repository
+            and let us know what you were doing when this error occurred.
+            We will fix it as soon as possible. Sorry for any inconvenience caused.
+          </p>
+        {% endblock %}
+      </div>
+      {# <div class="col-md-6 col-md-offset-3">
+          {% block error_graphics %}
+              <img class="librecores-error-image" src="{{ asset('img/400.svg') }}" />
+          {% endblock &}
+      </div> #}
+    </div>
+  </div>
+{% endblock %}

--- a/site/app/Resources/TwigBundle/views/Exception/error400.html.twig
+++ b/site/app/Resources/TwigBundle/views/Exception/error400.html.twig
@@ -1,0 +1,5 @@
+{% extends '@Twig/Exception/error.html.twig' %}
+
+{% block error_title %}
+  We received a request that we could not understand
+{% endblock %}

--- a/site/app/Resources/TwigBundle/views/Exception/error403.html.twig
+++ b/site/app/Resources/TwigBundle/views/Exception/error403.html.twig
@@ -1,0 +1,18 @@
+{% extends '@Twig/Exception/error.html.twig' %}
+
+{% block error_title %}
+  Unauthorized
+{% endblock %}
+
+{% block error_description %}
+  You are not authorized to perform this action.
+{% endblock %}
+
+{% block error_explanation %}
+  <p>
+    You do not have sufficient previlages to perform this action on the specified object.
+  </p>
+  <p>
+    If you believe this is an error, please <a href="https://github.com/librecores/librecores-web/issues">open an issue</a> at our Github repository and let us know what you were doing when this error occurred.
+  </p>
+{% endblock %}

--- a/site/app/Resources/TwigBundle/views/Exception/error404.html.twig
+++ b/site/app/Resources/TwigBundle/views/Exception/error404.html.twig
@@ -1,0 +1,16 @@
+{% extends '@Twig/Exception/error.html.twig' %}
+
+{% block error_title %}
+  We could not find what you were looking for
+{% endblock %}
+
+{% block error_description %}
+  The requested resource couldn't be located.
+{% endblock %}
+
+{% block error_explanation %}
+  <p>
+    Checkout for any URL misspelling or an outdated bookmark.
+    If an internal link led you here, please <a href="https://github.com/librecores/librecores-web/issues">let us know</a>.
+  </p>
+{% endblock %}


### PR DESCRIPTION
This PR replaces Symfony's default error pages with ones that align better with the website style.

Fix for #109 