### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{package.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,9 +8,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,*.yml}]
-indent_style = space
-indent_size = 2
-
 [*.md]
 trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.php]
+indent_size = 4
+


### PR DESCRIPTION
An editorconfig will help to synchronize  whitespace settings such as tab size, indentation type across all editors. This will help new contributors in writing code that better adheres to the code style of the rest of the repo. ( #133 )

This pull request creates an editorconfig file for the project with the following settings. It closes issue #133 

| Setting | Value |
| --------- | ------- |
| Indent style | `space` |
| Indent size | 2 |
| Line endings | `lf` |
| Character encoding | `utf-8` |
| Trim trailing whitespace | yes |
| Insert final newline | yes |