### PR TITLE
Install and setup the Easy-Admin bundle

### DIFF
--- a/site/app/AppKernel.php
+++ b/site/app/AppKernel.php
@@ -34,6 +34,7 @@ class AppKernel extends Kernel
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
             $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
+            $bundles[] = new JavierEguiluz\Bundle\EasyAdminBundle\EasyAdminBundle();
         }
 
         return $bundles;

--- a/site/app/config/config_dev.yml
+++ b/site/app/config/config_dev.yml
@@ -51,3 +51,18 @@ assetic:
 
 #swiftmailer:
 #    delivery_address: me@example.com
+
+easy_admin:
+    site_name: 'LibreCores Admin'
+    design:
+        form_theme:   'horizontal'
+        color_scheme: 'dark'
+    entities:
+        - Librecores\ProjectRepoBundle\Entity\GitSourceRepo
+        - Librecores\ProjectRepoBundle\Entity\Organization
+        - Librecores\ProjectRepoBundle\Entity\OrganizationMember
+        - Librecores\ProjectRepoBundle\Entity\Project
+#        - Librecores\ProjectRepoBundle\Entity\SourceStats
+#        - Librecores\ProjectRepoBundle\Entity\SourceStatsAuthor
+#        - Librecores\ProjectRepoBundle\Entity\SourceStatsCommitHistogram
+        - Librecores\ProjectRepoBundle\Entity\User

--- a/site/app/config/routing_dev.yml
+++ b/site/app/config/routing_dev.yml
@@ -10,5 +10,10 @@ _errors:
     resource: "@TwigBundle/Resources/config/routing/errors.xml"
     prefix:   /_error
 
+easy_admin_bundle:
+    resource: "@EasyAdminBundle/Controller/"
+    type:     annotation
+    prefix:   /admin
+
 _main:
     resource: routing.yml

--- a/site/app/config/security.yml
+++ b/site/app/config/security.yml
@@ -50,6 +50,9 @@ security:
                 domain: ~ # Defaults to the current domain from $_SERVER
 
     access_control:
+        # only admins should be able to access the easy admin panel
+        - { path: ^/admin, role: ROLE_ADMIN }
+
         # login and registration pages should work for non-logged-in users
         - { path: ^/user/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/user/register, role: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/site/composer.json
+++ b/site/composer.json
@@ -36,7 +36,8 @@
 		"symfony/http-kernel" : "~3.2.3",
 		"knplabs/github-api": "^2.3",
 		"php-http/guzzle6-adapter": "^1.1",
-		"symfony/cache": "^3.2"
+		"symfony/cache": "^3.2",
+		"javiereguiluz/easyadmin-bundle": "^1.16"
 	},
 	"scripts" : {
 		"post-install-cmd" : [

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b020928fb5e9158c82525f8744e115b",
+    "content-hash": "b4c1bf7ff48f0a9fb556479f3250b182",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1736,6 +1736,92 @@
             "time": "2015-11-10T17:04:01+00:00"
         },
         {
+            "name": "javiereguiluz/easyadmin-bundle",
+            "version": "v1.16.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/javiereguiluz/EasyAdminBundle.git",
+                "reference": "129d3f33b23668c5829106118c1fb1b677365756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/javiereguiluz/EasyAdminBundle/zipball/129d3f33b23668c5829106118c1fb1b677365756",
+                "reference": "129d3f33b23668c5829106118c1fb1b677365756",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "~1.5",
+                "doctrine/common": "^2.4.0",
+                "doctrine/doctrine-bundle": "~1.2",
+                "doctrine/orm": "~2.3",
+                "pagerfanta/pagerfanta": "~1.0,>=1.0.1",
+                "php": ">=5.3.0",
+                "sensio/framework-extra-bundle": "~2.3|~3.0,>=3.0.2",
+                "symfony/asset": "~2.3|~3.0",
+                "symfony/config": "~2.3|~3.0",
+                "symfony/dependency-injection": "~2.3|~3.0",
+                "symfony/doctrine-bridge": "~2.3|~3.0",
+                "symfony/event-dispatcher": "~2.3|~3.0",
+                "symfony/form": "~2.3|~3.0",
+                "symfony/framework-bundle": "~2.3|~3.0",
+                "symfony/http-foundation": "~2.3|~3.0",
+                "symfony/http-kernel": "~2.3|~3.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/property-access": "~2.3|~3.0",
+                "symfony/security-bundle": "~2.3|~3.0",
+                "symfony/translation": "~2.3|~3.0",
+                "symfony/twig-bridge": "^2.3.4|~3.0",
+                "symfony/twig-bundle": "~2.3|~3.0",
+                "symfony/validator": "~2.3|~3.0",
+                "twig/extensions": "~1.0",
+                "twig/twig": "~1.14,>=1.14.2|~2.0"
+            },
+            "require-dev": {
+                "doctrine/doctrine-fixtures-bundle": "~2.2",
+                "phpunit/phpunit": "~4.4",
+                "psr/log": "~1.0",
+                "symfony/browser-kit": "~2.3|~3.0",
+                "symfony/console": "~2.3|~3.0",
+                "symfony/css-selector": "~2.3|~3.0",
+                "symfony/dom-crawler": "~2.3|~3.0",
+                "symfony/finder": "~2.3|~3.0",
+                "symfony/phpunit-bridge": "^2.7",
+                "symfony/var-dumper": "~2.3|~3.0",
+                "symfony/yaml": "~2.3|~3.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "JavierEguiluz\\Bundle\\EasyAdminBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Javier Eguiluz",
+                    "email": "javiereguiluz@gmail.com"
+                },
+                {
+                    "name": "Project Contributors",
+                    "homepage": "http://github.com/javiereguiluz/easyadmin/blob/master/CONTRIBUTORS.md"
+                }
+            ],
+            "description": "Admin generator for Symfony applications",
+            "homepage": "https://github.com/javiereguiluz/EasyAdminBundle",
+            "keywords": [
+                "admin",
+                "backend",
+                "generator"
+            ],
+            "time": "2017-04-08T18:35:00+00:00"
+        },
+        {
             "name": "jdorn/sql-formatter",
             "version": "v1.2.17",
             "source": {
@@ -2338,6 +2424,75 @@
                 "service proxies"
             ],
             "time": "2017-05-04T11:12:50+00:00"
+        },
+        {
+            "name": "pagerfanta/pagerfanta",
+            "version": "v1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/whiteoctober/Pagerfanta.git",
+                "reference": "29aade64addfdfb12c05aabf160f09d1aea6b143"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/whiteoctober/Pagerfanta/zipball/29aade64addfdfb12c05aabf160f09d1aea6b143",
+                "reference": "29aade64addfdfb12c05aabf160f09d1aea6b143",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "doctrine/orm": "~2.3",
+                "doctrine/phpcr-odm": "1.*",
+                "jackalope/jackalope-doctrine-dbal": "1.*",
+                "jmikola/geojson": "~1.0",
+                "mandango/mandango": "~1.0@dev",
+                "mandango/mondator": "~1.0@dev",
+                "phpunit/phpunit": "~4 | ~5",
+                "propel/propel": "~2.0@dev",
+                "propel/propel1": "~1.6",
+                "ruflin/elastica": "~1.3",
+                "solarium/solarium": "~3.1"
+            },
+            "suggest": {
+                "doctrine/mongodb-odm": "To use the DoctrineODMMongoDBAdapter.",
+                "doctrine/orm": "To use the DoctrineORMAdapter.",
+                "doctrine/phpcr-odm": "To use the DoctrineODMPhpcrAdapter. >= 1.1.0",
+                "mandango/mandango": "To use the MandangoAdapter.",
+                "propel/propel": "To use the Propel2Adapter",
+                "propel/propel1": "To use the PropelAdapter",
+                "solarium/solarium": "To use the SolariumAdapter."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Pagerfanta\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pablo Díez",
+                    "email": "pablodip@gmail.com"
+                }
+            ],
+            "description": "Pagination for PHP 5.3",
+            "keywords": [
+                "page",
+                "pagination",
+                "paginator",
+                "paging"
+            ],
+            "time": "2017-03-20T13:46:15+00:00"
         },
         {
             "name": "paragonie/random_compat",

--- a/site/src/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidator.php
+++ b/site/src/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidator.php
@@ -39,7 +39,7 @@ class UserOrgNameValidator extends ConstraintValidator
      * @var string[]
      */
     const RESERVED_NAMES = [ 'org', 'orgs', 'planet', 'project', 'projects',
-                             'search', 'static', 'unassigned', 'user' ];
+                             'search', 'static', 'unassigned', 'user', 'admin', 'administrator' ];
 
     /**
      * Routes that are excluded from checking for a match in userOrgReserved()


### PR DESCRIPTION
- Simplest setup - see docs for more options
- Only development environment integration
- Only users with the 'ROLE_ADMIN' role can access it
- Reserves the 'admin' and 'administrator' user/org names
- Needs its assets installed

Full Documentation:
http://symfony.com/doc/current/bundles/EasyAdminBundle/index.html

Related Issue: #122