### PR TITLE
Add support for private Vagrant config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *~
 
+# IntelliJ IDEA project files
+.idea
+
 # Eclipse project files
 .buildpath
 .project
@@ -9,3 +12,6 @@
 
 # secrets of all kinds
 /aws-secrets.include
+
+# private vagrant configutation
+/vagrant/Vagrantfile.private

--- a/doc/src/devenv/quickstart.rst
+++ b/doc/src/devenv/quickstart.rst
@@ -79,6 +79,25 @@ If you don't use NFS, ...
 
 - Open the file ``vagrant/Vagrantfile`` and uncomment the corresponding lines of configuration.
 
+**Customizing Vagrant Configuration**
+
+If you need to customize Vagrant configuration, such as adding networks or  you can add a ``Vagrantfile.private`` under the `vagrant` folder with your customizations. However, not all settings in ``Vagrantfile`` can be overridden.
+
+Example: The following configuration uses SSHFS in place of NFS (you need to disable NFS in your host though) and attaches the VM to a bridged network to acquire a public IP.
+
+.. code-block:: ruby
+
+    Vagrant.configure("2") do |config|
+        config.vm.synced_folder ".",  "/vagrant", id: "vagrant-root",type: 'sshfs'
+        config.vm.synced_folder "..", "/var/www/lc", id: "application", type: 'sshfs'
+        config.vm.define 'librecores' do |node|
+            node.vm.network :public_network, ip: '10.42.0.99'
+        end
+        config.vm.provider :virtualbox do |v|
+            v.cpus = 2
+            v.memory = 2048
+        end
+    end
 
 Step 4: Develop!
 ----------------

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,10 @@
+# Vagrant configuration
+This directory contains a vagrant configuration that sets up a development
+environment resembling the production configuration at LibreCores.org
+as closely as possible.
+
+## Customizing Vagrant configuaration
+If you need to customize Vagrant configuration, you can add a `Vagrantfile.private`
+file with your customizations.
+
+See the docs section regarding Vagrant configuration for details.

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -54,3 +54,5 @@ Vagrant.configure("2") do |config|
     end
 end
 
+private_vagrantfile = File.expand_path('./Vagrantfile.private', __dir__)
+load private_vagrantfile if File.exists?(private_vagrantfile)


### PR DESCRIPTION
Allows the developer to customize Vagrant configuration as needed locally.

### Why ?
Because symfony cache generation, batch operations on MySQL on the VM was very slow, I wanted to run the VM in another powerful machine in my home network. 