### PR TITLE
Add functional tests for routes

### DIFF
--- a/site/tests/Librecores/PlanetRepoBundle/Controller/DefaultControllerTest.php
+++ b/site/tests/Librecores/PlanetRepoBundle/Controller/DefaultControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Librecores\ProjectRepoBundle\Controller;
+
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityRepository;
+use FOS\UserBundle\Doctrine\UserManager;
+use Librecores\ProjectRepoBundle\Entity\User;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Test for DefaultController
+ *
+ * @author Amitosh Swain Mahapatra <amitosh.swain@gmail.com>
+ */
+class DefaultControllerTest extends WebTestCase
+{
+    public function testUserOrOrgViewAction()
+    {
+        // We use separate environments for testing in local and CI
+        // if env var SYMFONY_ENV exists, then pass it as options to kernel builder
+        // else fallback to default. This is required for all tests
+
+        $env = getenv('SYMFONY_ENV');
+        $client = static::createClient($env ? [ 'environment' => $env ] : []);
+
+        // test for a user
+
+        $crawler = $client->request('GET', '/test');
+
+        $this->assertEquals($client->getResponse()->getStatusCode(), 200);
+
+        // ensure header contains user's name
+        $this->assertEquals($crawler->filter('.librecores-user-page-header > h1')->eq(0)->text(),'test');
+
+        $crawler = $client->request('GET', '/openrisc');
+        $this->assertEquals($crawler->filter('html body div#maincontent.container h1')->text(),'openrisc : OpenRISC');
+    }
+}

--- a/site/tests/Librecores/SiteBundle/Controller/DefaultControllerTest.php
+++ b/site/tests/Librecores/SiteBundle/Controller/DefaultControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Librecores\SiteBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Test for default controller.
+ *
+ * @author Amitosh Swain Mahapatra <amitosh.swain@gmail.com>
+ */
+class DefaultControllerTest extends WebTestCase
+{
+    /**
+     * Test home page (/)
+     */
+    public function testHomeAction()
+    {
+        // We use separate environments for testing in local and CI
+        // if env var SYMFONY_ENV exists, then pass it as options to kernel builder
+        // else fallback to default. This is required for all tests
+
+        $env = getenv('SYMFONY_ENV');
+        $client = static::createClient($env ? [ 'environment' => $env ] : []);
+
+        $crawler = $client->request('GET', '/');
+
+        $this->assertEquals($client->getResponse()->getStatusCode(), 200);  // must be a 200 OK response
+
+        // since most of the content is static, extensive testing is not required, asserting presence of certain key elements
+        $this->assertEquals($crawler->filter('.librecores-home-banner-wordmark')->html(), 'LibreCores');
+        $this->assertEquals($crawler->filter('.librecores-home-banner-claim')->html(), 'We drive Free and Open Digital Hardware.');   //expect certain values
+    }
+
+    // pageAction is not testable
+}


### PR DESCRIPTION
This PR ~~sets up Travis CI for~~ adds functional tests ~~involving MySQL and RabbitMQ~~. 

It adds a test for the DefaultController, which should be used as a template for writing further tests.

#148 