### PR TITLE
Add meta tag for correct viewport sizing

### DIFF
--- a/site/app/Resources/views/base.html.twig
+++ b/site/app/Resources/views/base.html.twig
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
   <title>{% block title %}{% endblock %}</title>
 
   <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}" />
@@ -56,7 +59,7 @@
           <li><a href="{{ path('librecores_planet_homepage') }}">Planet LibreCores</a></li>
               <li><a href="{{ path('librecores_site_page', {'page': 'community-hub'}) }}">Community Hub</a></li>
             </ul>
-          </li> 
+          </li>
           <li><a href="{{ path('librecores_site_page', {'page': 'librecores-ci'}) }}">LibreCores CI</a></li>
           <li><a href="{{ path('librecores_site_page', {'page': 'about'}) }}">About</a></li>
         </ul>


### PR DESCRIPTION
Closes #171 

A three-line fix to make sure pages are properly displayed on mobile.
The viewport tag instructs browser to render at the device width, and not in a scaled virtual viewport.

https://developer.mozilla.org/en/docs/Mozilla/Mobile/Viewport_meta_tag