### PR TITLE
Fix error when listing organitations

### DIFF
--- a/site/src/Librecores/ProjectRepoBundle/Repository/OrganizationRepository.php
+++ b/site/src/Librecores/ProjectRepoBundle/Repository/OrganizationRepository.php
@@ -3,6 +3,7 @@ namespace Librecores\ProjectRepoBundle\Repository;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityRepository;
+use Librecores\ProjectRepoBundle\Entity\User;
 
 /**
  * OrganizationRepository


### PR DESCRIPTION
Symfony was giving an error when a user listed repositories:

    Type error: Argument 1 passed to Librecores\ProjectRepoBundle\Repository\OrganizationRepository::findAllByMemberOrderedByName() must be an instance of Librecores\ProjectRepoBundle\Repository\User, instance of Librecores\ProjectRepoBundle\Entity\User given, called in /var/www/lc/site/src/Librecores/ProjectRepoBundle/Controller/OrganizationController.php on line 25

This fix is rather trivial by importing the correct class into the
Repository.