### PR TITLE
ansible: replace deprecated sudo with become

### DIFF
--- a/ansible/dev-vagrant.yml
+++ b/ansible/dev-vagrant.yml
@@ -1,7 +1,7 @@
 ---
 # Development environment on a single machine with dummy credentials
 - hosts: all
-  sudo: yes
+  become: true
   roles:
     - dev-vagrant
   vars_files:

--- a/ansible/production-aws-configure-local-ssh.yml
+++ b/ansible/production-aws-configure-local-ssh.yml
@@ -3,7 +3,6 @@
   hosts: localhost
   connection: local
   gather_facts: False
-  sudo: false
   vars:
     local_home: "{{ lookup('env','HOME') }}"
     local_user: "{{ lookup('env','USER') }}"

--- a/ansible/production-aws-deploy.yml
+++ b/ansible/production-aws-deploy.yml
@@ -5,7 +5,7 @@
   hosts: production
   gather_facts: true
   user: ubuntu
-  sudo: yes
+  become: true
   roles:
     - production-aws
   vars_files:

--- a/ansible/production-aws-initdata.yml
+++ b/ansible/production-aws-initdata.yml
@@ -5,7 +5,7 @@
   hosts: production
   gather_facts: true
   user: ubuntu
-  sudo: yes
+  become: true
   roles:
     - initdata
   vars_files:

--- a/ansible/production-aws-provision.yml
+++ b/ansible/production-aws-provision.yml
@@ -100,7 +100,7 @@
   hosts: tag_group_librecores_production
   gather_facts: False
   user: ubuntu
-  sudo: yes
+  become: true
   tasks:
     - name: 'install python2'
       raw: sudo apt-get -y install python-simplejson
@@ -109,7 +109,7 @@
   hosts: tag_group_librecores_production
   gather_facts: True
   user: ubuntu
-  sudo: yes
+  become: true
   tasks:
     - name: Format disk
       filesystem: fstype=ext4 dev=/dev/xvdf

--- a/ansible/production-aws-resetdata.yml
+++ b/ansible/production-aws-resetdata.yml
@@ -5,7 +5,7 @@
   hosts: staging
   gather_facts: true
   user: ubuntu
-  sudo: yes
+  become: true
   roles:
     - resetdata
   vars_files:

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -32,7 +32,7 @@
   tags: ntp
 
 - name: Install common system packages
-  sudo: yes
+  become: true
   apt:  pkg={{ item }} state=installed
   with_items:
     - curl

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install MySQL server
-  sudo: yes
+  become: true
   apt:  pkg=mysql-server state=installed
 
 # move data directory to EBS

--- a/ansible/roles/initdata/tasks/librecores-site.yml
+++ b/ansible/roles/initdata/tasks/librecores-site.yml
@@ -2,22 +2,22 @@
 # Insert development test data into all systems
 
 - name: Insert database fixtures
-  sudo: yes
-  sudo_user: "{{ web_user }}"
+  become: true
+  become_user: "{{ web_user }}"
   command: php bin/console doctrine:fixtures:load -n
   args:
     chdir: /var/www/lc/site
 
 - name: Update all projects from their source repository
-  sudo: yes
-  sudo_user: "{{ web_user }}"
+  become: true
+  become_user: "{{ web_user }}"
   command: php bin/console librecores:update-repos
   args:
     chdir: /var/www/lc/site
 
 - name: Run planet generator for the first time
-  sudo: yes
-  sudo_user: "{{ web_user }}"
+  become: true
+  become_user: "{{ web_user }}"
   shell: /var/www/lc/planet/generate.sh
   args:
     chdir: /var/www/lc/planet

--- a/ansible/roles/resetdata/tasks/main.yml
+++ b/ansible/roles/resetdata/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
 - name: Drop all tables from librecores database
-  sudo: yes
-  sudo_user: "{{ web_user }}"
+  become: true
+  become_user: "{{ web_user }}"
   command: php bin/console doctrine:schema:drop --force
   args:
     chdir: /var/www/lc/site
 
 - name: Let doctrine generate database schema
-  sudo: yes
-  sudo_user: "{{ web_user }}"
+  become: true
+  become_user: "{{ web_user }}"
   command: php bin/console doctrine:schema:create
   args:
     chdir: /var/www/lc/site
 
 - name: Make sure migrations metadata is up-to-date
-  sudo: yes
-  sudo_user: "{{ web_user }}"
+  become: true
+  become_user: "{{ web_user }}"
   command: php bin/console doctrine:migrations:version --add --all
   args:
     chdir: /var/www/lc/site

--- a/ansible/roles/web/tasks/librecores-blog.yml
+++ b/ansible/roles/web/tasks/librecores-blog.yml
@@ -4,7 +4,7 @@
   file: dest=/var/log/nginx/librecores-blog state=directory
 
 - name: Configure nginx blog site in nginx
-  sudo: yes
+  become: true
   template: src=nginx/librecores-blog.tpl dest=/etc/nginx/sites-available/librecores-blog
   notify: restart nginx
 

--- a/ansible/roles/web/tasks/librecores-site.yml
+++ b/ansible/roles/web/tasks/librecores-site.yml
@@ -171,8 +171,8 @@
   meta: flush_handlers
 
 - name: Run all database migrations (also creates initial tables if necessary)
-  sudo: yes
-  sudo_user: "{{ web_user }}"
+  become: true
+  become_user: "{{ web_user }}"
   command: php bin/console doctrine:migrations:migrate -n
   environment: "{{ symfony_config }}"
   args:

--- a/ansible/roles/web/tasks/nginx.yml
+++ b/ansible/roles/web/tasks/nginx.yml
@@ -1,7 +1,7 @@
 ---
 # Install nginx web server
 - name: Install nginx
-  sudo: yes
+  become: true
   apt:  pkg=nginx state=installed
 
 - name: Add gzip compression config

--- a/ansible/roles/web/tasks/php.yml
+++ b/ansible/roles/web/tasks/php.yml
@@ -4,38 +4,38 @@
   apt_repository: repo='ppa:ondrej/php'
 
 - name: Install PHP FPM
-  sudo: yes
+  become: true
   apt:  package=php{{ php_version }}-fpm state=installed
 
 - name: Setup support for PHP in nginx
-  sudo: yes
+  become: true
   template: src=nginx/upstream_php.conf.tpl dest=/etc/nginx/conf.d/upstream_php{{ php_version }}.conf
   notify: restart nginx
 
 - name: Install PHP CLI
-  sudo: yes
+  become: true
   apt:  package=php{{ php_version }}-cli state=installed
 
 # OS packaged PHP extensions
 - name: Install packaged PHP extensions
-  sudo: yes
+  become: true
   apt:  package=php{{php_version}}-{{ item }} state=installed
   with_items: "{{ php_extensions_packaged }}"
 
 - name: Enable packaged PHP extensions for all SAPIs
-  sudo: yes
+  become: true
   # creates= only accepts one file; phpenmod also creates the fpm symlink
   command: /usr/sbin/phpenmod -s ALL {{ item }} creates=/etc/php/{{ php_version }}/cli/conf.d/20-{{ item }}.ini
   with_items: "{{ php_extensions_packaged }}"
   notify: restart php-fpm
 
 - name: Install packaged PHP extensions for development
-  sudo: yes
+  become: true
   apt:  package=php{{php_version}}-{{ item }} state=installed
   with_items: "{{ php_devel_extensions_packaged }}"
 
 - name: Enable packaged PHP extensions for development for all SAPIs
-  sudo: yes
+  become: true
   # creates= only accepts one file; phpenmod also creates the fpm symlink
   command: /usr/sbin/phpenmod -s ALL {{ item }} creates=/etc/php/{{ php_version }}/cli/conf.d/20-{{ item }}.ini
   with_items: "{{ php_devel_extensions_packaged }}"
@@ -43,17 +43,17 @@
 
 # PHP extensions from PECL
 - name: Install PECL-installed PHP extensions
-  sudo: yes
+  become: true
   shell: echo "\n" | /usr/bin/pecl install {{ item.package }} creates=/usr/lib/php/20151012/{{ item.name }}.so
   with_items: "{{ php_extensions_pecl }}"
 
 - name: Configure PECL-installed PHP extensions
-  sudo: yes
+  become: true
   template: src=php_extension.tpl dest=/etc/php/mods-available/{{ item.name }}.ini
   with_items: "{{ php_extensions_pecl }}"
 
 - name: Enable PECL-installed PHP extensions for all SAPIs (through PECL)
-  sudo: yes
+  become: true
   # creates= only accepts one file; phpenmod also creates the fpm symlink
   command: /usr/sbin/phpenmod -s ALL {{ item.name }} creates=/etc/php/{{ php_version }}/cli/conf.d/20-{{ item.name }}.ini
   with_items: "{{ php_extensions_pecl }}"

--- a/ansible/roles/web/tasks/rabbitmq.yml
+++ b/ansible/roles/web/tasks/rabbitmq.yml
@@ -9,15 +9,15 @@
   get_url: url=https://www.rabbitmq.com/rabbitmq-release-signing-key.asc dest=/tmp/rabbitmq-release-signing-key.asc
 
 - name: Add RabbitMQ key
-  sudo: yes
+  become: true
   command: apt-key add /tmp/rabbitmq-release-signing-key.asc
 
 - name: Update apt again
-  sudo: yes
+  become: true
   apt:  update_cache=yes
 
 - name: Install RabbitMQ
-  sudo: yes
+  become: true
   apt:  pkg=rabbitmq-server state=installed
 
 - name: Enable RabbitMQ plugins

--- a/ansible/staging-aws-configure-local-ssh.yml
+++ b/ansible/staging-aws-configure-local-ssh.yml
@@ -3,7 +3,6 @@
   hosts: localhost
   connection: local
   gather_facts: False
-  sudo: false
   vars:
     local_home: "{{ lookup('env','HOME') }}"
     local_user: "{{ lookup('env','USER') }}"

--- a/ansible/staging-aws-deploy.yml
+++ b/ansible/staging-aws-deploy.yml
@@ -5,7 +5,7 @@
   hosts: staging
   gather_facts: true
   user: ubuntu
-  sudo: yes
+  become: true
   roles:
     - staging-aws
   vars_files:

--- a/ansible/staging-aws-initdata.yml
+++ b/ansible/staging-aws-initdata.yml
@@ -5,7 +5,7 @@
   hosts: staging
   gather_facts: true
   user: ubuntu
-  sudo: yes
+  become: true
   roles:
     - initdata
   vars_files:

--- a/ansible/staging-aws-provision.yml
+++ b/ansible/staging-aws-provision.yml
@@ -104,7 +104,7 @@
   hosts: tag_group_librecores_staging
   gather_facts: False
   user: ubuntu
-  sudo: yes
+  become: true
   tasks:
     - name: 'install python2'
       raw: sudo apt-get -y install python-simplejson
@@ -113,7 +113,7 @@
   hosts: tag_group_librecores_staging
   gather_facts: True
   user: ubuntu
-  sudo: yes
+  become: true
   tasks:
     - name: Format disk
       filesystem: fstype=ext4 dev=/dev/xvdf

--- a/ansible/staging-aws-resetdata.yml
+++ b/ansible/staging-aws-resetdata.yml
@@ -5,7 +5,7 @@
   hosts: staging
   gather_facts: true
   user: ubuntu
-  sudo: yes
+  become: true
   roles:
     - resetdata
   vars_files:


### PR DESCRIPTION
This replaces the deprecated 'sudo' and 'sudo_user' parameters with
their replacement 'become' and 'become_user'.