### PR TITLE
Fix typo in twig property attribute name

### DIFF
--- a/site/src/Librecores/ProjectRepoBundle/Resources/views/Default/project_search.html.twig
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/views/Default/project_search.html.twig
@@ -88,9 +88,9 @@ LibreCores Search
             {{ project.sourceRepo.sourceStats.mostUsedLanguage }}
           </span>
           {%  endif %}
-          {% if project.dateLastActivityOccured %}
+          {% if project.dateLastActivityOccurred %}
           <span class="updated">
-          <i class="fa fa-history"></i> Updated {{ project.dateLastActivityOccured | time_diff }}
+          <i class="fa fa-history"></i> Updated {{ project.dateLastActivityOccurred | time_diff }}
           </span>
           {% endif %}
         </div>


### PR DESCRIPTION
Enables display of last updated date in search results.

This is miraculously suppressed in production, while dev crashes
Closes #190