### PR TITLE
Password Reset

### DIFF
--- a/site/app/Resources/FOSUserBundle/views/Resetting/check_email.html.twig
+++ b/site/app/Resources/FOSUserBundle/views/Resetting/check_email.html.twig
@@ -1,0 +1,17 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block fos_user_content %}
+    <div class="center-block">
+        <div class="panel panel-default">
+            <div class="panel-heading"><h3 class="panel-title">Reset Password</h3></div>
+            <div class="panel-body">
+                <p>
+                    {{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime})|nl2br }}
+                </p>
+            </div>
+        </div>
+    </div>
+    </div>
+{% endblock fos_user_content %}

--- a/site/app/Resources/FOSUserBundle/views/Resetting/check_email.html.twig
+++ b/site/app/Resources/FOSUserBundle/views/Resetting/check_email.html.twig
@@ -3,15 +3,14 @@
 {% trans_default_domain 'FOSUserBundle' %}
 
 {% block fos_user_content %}
-    <div class="center-block">
-        <div class="panel panel-default">
-            <div class="panel-heading"><h3 class="panel-title">Reset Password</h3></div>
-            <div class="panel-body">
-                <p>
-                    {{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime})|nl2br }}
-                </p>
-            </div>
-        </div>
+  <div class="center-block">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Reset Password</h3>
+      </div>
+      <div class="panel-body">
+        <p>{{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime})|nl2br }}</p>
+      </div>
     </div>
-    </div>
+  </div>
 {% endblock fos_user_content %}

--- a/site/app/Resources/FOSUserBundle/views/Resetting/email.txt.twig
+++ b/site/app/Resources/FOSUserBundle/views/Resetting/email.txt.twig
@@ -1,0 +1,13 @@
+{% trans_default_domain 'FOSUserBundle' %}
+{% block subject %}
+{%- autoescape false -%}
+{{ 'resetting.email.subject'|trans({'%username%': user.username}) }}
+{%- endautoescape -%}
+{% endblock %}
+
+{% block body_text %}
+{% autoescape false %}
+{{ 'resetting.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{% endautoescape %}
+{% endblock %}
+{% block body_html %}{% endblock %}

--- a/site/app/Resources/FOSUserBundle/views/Resetting/email.txt.twig
+++ b/site/app/Resources/FOSUserBundle/views/Resetting/email.txt.twig
@@ -1,13 +1,284 @@
 {% trans_default_domain 'FOSUserBundle' %}
+
 {% block subject %}
-{%- autoescape false -%}
-{{ 'resetting.email.subject'|trans({'%username%': user.username}) }}
-{%- endautoescape -%}
+  {%- autoescape false -%}
+  {{ 'resetting.email.subject'|trans({'%username%': user.username,
+                                      '%confirmationUrl%': confirmationUrl}) }}
+    {%- endautoescape -%}
 {% endblock %}
 
 {% block body_text %}
-{% autoescape false %}
-{{ 'resetting.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
-{% endautoescape %}
+  {% autoescape false %}
+Hello {{ user.username }}!
+
+You have requested a password reset on your LibreCores account.
+
+To reset your password please click on the following link (or copy it into your browser):
+
+{{ confirmationUrl }}
+
+--
+
+You are receiving this email because you (or someone posing as you) requested a password reset at LibreCores.
+
+LibreCores is a project by The Free and Open Source Silicon Foundation C.i.C.
+71-75 Shelton Street, London, WC2H 9JQ, United Kingdom
+  {% endautoescape %}
 {% endblock %}
-{% block body_html %}{% endblock %}
+
+{% block body_html %}
+  <html lang="en">
+  <head>
+    <title></title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <style type="text/css">
+      /* CLIENT-SPECIFIC STYLES */
+      #outlook a {
+        padding: 0;
+      }
+
+      /* Force Outlook to provide a "view in browser" message */
+      .ReadMsgBody {
+        width: 100%;
+      }
+
+      .ExternalClass {
+        width: 100%;
+      }
+
+      /* Force Hotmail to display emails at full width */
+      .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {
+        line-height: 100%;
+      }
+
+      /* Force Hotmail to display normal line spacing */
+      body, table, td, a {
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+
+      /* Prevent WebKit and Windows mobile changing default text sizes */
+      table, td {
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      /* Remove spacing between tables in Outlook 2007 and up */
+      img {
+        -ms-interpolation-mode: bicubic;
+      }
+
+      /* Allow smoother rendering of resized image in Internet Explorer */
+      /* RESET STYLES */
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      img {
+        border: 0;
+        height: auto;
+        line-height: 100%;
+        outline: none;
+        text-decoration: none;
+      }
+
+      table {
+        border-collapse: collapse !important;
+      }
+
+      body {
+        height: 100% !important;
+        margin: 0;
+        padding: 0;
+        width: 100% !important;
+      }
+
+      /* iOS BLUE LINKS */
+      .appleBody a {
+        color: #68440a;
+        text-decoration: none;
+      }
+
+      .appleFooter a {
+        color: #999999;
+        text-decoration: none;
+      }
+
+      /* MOBILE STYLES */
+      @media screen and (max-width: 525px) {
+        /* ALLOWS FOR FLUID TABLES */
+        table[class="wrapper"] {
+          width: 100% !important;
+        }
+
+        /* ADJUSTS LAYOUT OF LOGO IMAGE */
+        td[class="logo"] {
+          text-align: left;
+          padding: 20px 0 20px 0 !important;
+        }
+
+        td[class="logo"] img {
+          margin: 0 auto !important;
+        }
+
+        /* USE THESE CLASSES TO HIDE CONTENT ON MOBILE */
+        td[class="mobile-hide"] {
+          display: none;
+        }
+
+        img[class="mobile-hide"] {
+          display: none !important;
+        }
+
+        img[class="img-max"] {
+          max-width: 100% !important;
+          height: auto !important;
+        }
+
+        /* FULL-WIDTH TABLES */
+        table[class="responsive-table"] {
+          width: 100% !important;
+        }
+
+        /* UTILITY CLASSES FOR ADJUSTING PADDING ON MOBILE */
+        td[class="padding"] {
+          padding: 10px 5% 15px 5% !important;
+        }
+
+        td[class="padding-copy"] {
+          padding: 10px 5% 10px 5% !important;
+          text-align: center;
+        }
+
+        td[class="padding-meta"] {
+          padding: 30px 5% 0px 5% !important;
+          text-align: center;
+        }
+
+        td[class="no-pad"] {
+          padding: 0 0 20px 0 !important;
+        }
+
+        td[class="no-padding"] {
+          padding: 0 !important;
+        }
+
+        td[class="section-padding"] {
+          padding: 50px 15px 50px 15px !important;
+        }
+
+        td[class="section-padding-bottom-image"] {
+          padding: 50px 15px 0 15px !important;
+        }
+
+        /* ADJUST BUTTONS ON MOBILE */
+        td[class="mobile-wrapper"] {
+          padding: 10px 5% 15px 5% !important;
+        }
+
+        table[class="mobile-button-container"] {
+          margin: 0 auto;
+          width: 100% !important;
+        }
+
+        a[class="mobile-button"] {
+          width: 80% !important;
+          padding: 15px !important;
+          border: 0 !important;
+          font-size: 16px !important;
+        }
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0;">
+
+    <!-- ONE COLUMN W/ BOTTOM IMAGE SECTION -->
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td bgcolor="#f8f8f8" align="center" style="padding: 0px 15px 40px 15px;" class="section-padding-bottom-image">
+          <table border="0" cellpadding="0" cellspacing="0" width="500" class="responsive-table">
+            <tr>
+              <td>
+                <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                  <tr>
+                    <td>
+                      <!-- COPY -->
+                      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                        <tr>
+                          <td align="center"
+                              style="font-size: 25px; font-family: Helvetica, Arial, sans-serif; color: #3fb0ac;font-size: 37px;font-weight: 700;padding: 12px 0;"
+                              class="padding-copy">Hello {{ user.username }}!</td>
+                        </tr>
+                        <tr>
+                          <td align="center"
+                              style="font-size: 25px; font-family: Helvetica, Arial, sans-serif; color: #333333;"
+                              class="padding-copy">You have requested a password reset on your LibreCores account.
+                          </td>
+                        </tr>
+                        <tr>
+                          <td align="center"
+                              style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;"
+                              class="padding-copy">To reset your account password please click on Reset Your Password.
+                          </td>
+                        </tr>
+
+                      </table>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <!-- BULLETPROOF BUTTON -->
+                      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="mobile-button-container">
+                        <tr>
+                          <td align="center" style="padding: 25px 0 0 0;" class="padding-copy">
+                            <table border="0" cellspacing="0" cellpadding="0" class="responsive-table">
+                              <tr>
+                                {% autoescape false %}
+                                  <td align="center"><a href="{{ confirmationUrl }}" target="_blank"
+                                                        style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #3fb0ac; border-top: 15px solid #3fb0ac; border-bottom: 15px solid #3fb0ac; border-left: 25px solid #3fb0ac; border-right: 25px solid #3fb0ac; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;"
+                                                        class="mobile-button">Reset Your Password &rarr;</a></td>
+                                {% endautoescape %}
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+    {#Footer#}
+    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed;">
+      <tr>
+        <td bgcolor="#ffffff" align="center">
+          <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+              <td style="padding: 20px 0px 20px 0px;">
+                <!-- UNSUBSCRIBE COPY -->
+                <table width="500" border="0" cellspacing="0" cellpadding="0" align="center" class="responsive-table">
+                  <tr>
+                    <td align="center" valign="middle"
+                        style="font-size: 12px; line-height: 18px; font-family: Helvetica, Arial, sans-serif; color:#666666;">
+                      <span class="appleFooter" style="color:#666666;">
+                      <p>You are receiving this email because you (or someone posing as you) requested a password reset at LibreCores.</p>
+                      <p>LibreCores is a project by The Free and Open Source Silicon Foundation C.i.C.<br>
+                      71-75 Shelton Street, London, WC2H 9JQ, United Kingdom</p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+  </html>
+{% endblock %}

--- a/site/app/Resources/FOSUserBundle/views/Resetting/request.html.twig
+++ b/site/app/Resources/FOSUserBundle/views/Resetting/request.html.twig
@@ -3,24 +3,25 @@
 {% trans_default_domain 'FOSUserBundle' %}
 
 {% block fos_user_content %}
-    <div class="center-block librecores-user-signupin-panel">
-        <div class="panel panel-default">
-            <div class="panel-heading"><h3 class="panel-title">Reset Password</h3></div>
-            <div class="panel-body">
-                <form action="{{ path('fos_user_resetting_send_email') }}" method="POST" class="fos_user_resetting_request">
-                    <div class="form-group">
-                        <label for="username">Email or Username:</label>
-                        <input type="text" class="form-control" id="username" name="username" required="required" />
-                    </div>
-                    <button class="btn btn-success btn-block" type="submit" id="_submit" name="_submit">Reset Password</button>
-                </form>
-                <hr/>
-                <div class="text-center">
-                    Don't have an account yet?<br/>
-                    <a href="{{ path('fos_user_registration_register') }}" style="font-weight: bold">Register now</a>
-                </div>
-            </div>
+  <div class="center-block librecores-user-signupin-panel">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Reset Password</h3>
+      </div>
+      <div class="panel-body">
+        <form action="{{ path('fos_user_resetting_send_email') }}" method="POST" class="fos_user_resetting_request">
+          <div class="form-group">
+            <label for="username">Email or Username:</label>
+            <input type="text" class="form-control" id="username" name="username" required="required" />
+          </div>
+        <button class="btn btn-success btn-block" type="submit" id="_submit" name="_submit">Reset Password</button>
+        </form>
+        <hr/>
+        <div class="text-center">
+          Don't have an account yet?<br/>
+          <a href="{{ path('fos_user_registration_register') }}" style="font-weight: bold">Register now</a>
         </div>
-    </div>
+      </div>
+      </div>
     </div>
 {% endblock fos_user_content %}

--- a/site/app/Resources/FOSUserBundle/views/Resetting/request.html.twig
+++ b/site/app/Resources/FOSUserBundle/views/Resetting/request.html.twig
@@ -1,0 +1,26 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block fos_user_content %}
+    <div class="center-block librecores-user-signupin-panel">
+        <div class="panel panel-default">
+            <div class="panel-heading"><h3 class="panel-title">Reset Password</h3></div>
+            <div class="panel-body">
+                <form action="{{ path('fos_user_resetting_send_email') }}" method="POST" class="fos_user_resetting_request">
+                    <div class="form-group">
+                        <label for="username">Email or Username:</label>
+                        <input type="text" class="form-control" id="username" name="username" required="required" />
+                    </div>
+                    <button class="btn btn-success btn-block" type="submit" id="_submit" name="_submit">Reset Password</button>
+                </form>
+                <hr/>
+                <div class="text-center">
+                    Don't have an account yet?<br/>
+                    <a href="{{ path('fos_user_registration_register') }}" style="font-weight: bold">Register now</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    </div>
+{% endblock fos_user_content %}

--- a/site/app/Resources/FOSUserBundle/views/Resetting/reset.html.twig
+++ b/site/app/Resources/FOSUserBundle/views/Resetting/reset.html.twig
@@ -1,0 +1,18 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block fos_user_content %}
+    <div class="center-block librecores-user-signupin-panel">
+        <div class="panel panel-default">
+            <div class="panel-heading"><h3 class="panel-title">Reset Password</h3></div>
+            <div class="panel-body">
+                {{ form_start(form, { 'action': path('fos_user_resetting_reset', {'token': token}), 'attr': { 'class': 'fos_user_resetting_reset' } }) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-success btn-block" type="submit" id="_submit" name="_submit">Reset Password</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+    </div>
+{% endblock fos_user_content %}

--- a/site/app/Resources/FOSUserBundle/views/Resetting/reset.html.twig
+++ b/site/app/Resources/FOSUserBundle/views/Resetting/reset.html.twig
@@ -3,16 +3,20 @@
 {% trans_default_domain 'FOSUserBundle' %}
 
 {% block fos_user_content %}
-    <div class="center-block librecores-user-signupin-panel">
-        <div class="panel panel-default">
-            <div class="panel-heading"><h3 class="panel-title">Reset Password</h3></div>
-            <div class="panel-body">
-                {{ form_start(form, { 'action': path('fos_user_resetting_reset', {'token': token}), 'attr': { 'class': 'fos_user_resetting_reset' } }) }}
-                {{ form_widget(form) }}
-                <button class="btn btn-success btn-block" type="submit" id="_submit" name="_submit">Reset Password</button>
-                {{ form_end(form) }}
-            </div>
-        </div>
+  <div class="center-block librecores-user-signupin-panel">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Reset Password</h3>
+      </div>
+      <div class="panel-body">
+        {{ form_start(form, { 'action': path('fos_user_resetting_reset', {'token': token}),
+                              'attr': { 'class': 'fos_user_resetting_reset' } }) }}
+        {{ form_widget(form) }}
+        <button class="btn btn-success btn-block" type="submit" id="_submit" name="_submit">
+          Reset Password
+        </button>
+        {{ form_end(form) }}
+      </div>
     </div>
-    </div>
+  </div>
 {% endblock fos_user_content %}

--- a/site/app/Resources/FOSUserBundle/views/Security/login.html.twig
+++ b/site/app/Resources/FOSUserBundle/views/Security/login.html.twig
@@ -55,6 +55,11 @@
     Don't have an account yet?<br/>
     <a href="{{ path('fos_user_registration_register') }}" style="font-weight: bold">Register now</a>
   </div>
+  <hr/>
+  <div class="text-center">
+    Forgot your password?<br/>
+    <a href="{{ path('fos_user_resetting_request') }}" style="font-weight: bold">Reset Password</a>
+  </div>
 </div>
 </div>
 </div>

--- a/site/app/config/routing.yml
+++ b/site/app/config/routing.yml
@@ -44,15 +44,29 @@ fos_user_register:
 
 fos_user_resetting:
     resource: "@FOSUserBundle/Resources/config/routing/resetting.xml"
-    prefix: /resetting
+    prefix: /user/resetting
 
-fos_user_profile:
-    resource: "@FOSUserBundle/Resources/config/routing/profile.xml"
-    prefix: /profile
+# Default landing page after user's password reset
+#
+# Disable if there is a better way (than overriding the FOS controller) to force the
+# landing page of a successful reset into the 'librecores.user.settings.profile' route
+# or even better to the 'librecores.user.settings.password' route.
+#
+fos_user_profile_show: # = librecores.user.settings.profile
+    path: /user/settings/profile
+    defaults: { _controller: LibrecoresProjectRepoBundle:User:profileSettings }
 
-fos_user_change_password:
-    resource: "@FOSUserBundle/Resources/config/routing/change_password.xml"
-    prefix: /profile
+# Handled by the 'librecores.user.settings.profile' route
+#
+#fos_user_profile:
+#    resource: "@FOSUserBundle/Resources/config/routing/profile.xml"
+#    prefix: /user/profile
+
+# Handled by the 'librecores.user.settings.password' route
+#
+#fos_user_change_password:
+#    resource: "@FOSUserBundle/Resources/config/routing/change_password.xml"
+#    prefix: /user/profile
 
 # Site routes ("static content")
 librecores_site:


### PR DESCRIPTION
This PR adds password reset functionality from the FOS user bundle as discussed in #192.

The link was added to the login page and the reset password UI now matches the reset of the site.

The four templates that are used for resetting the password are the following and correspond to the steps that the user follows when starting the reset process:

1. To reset your password visit the route with path `/user/request` which contains a simple form to fill your email address or username. The template for this page can be found at `site/app/Resources/FOSUserBundle/views/Resetting/request.html.twig`
2. A message is shown after you submit an existing email / username on the previous form. The url of this message page is `/user/check-email?username=$USERNAME$` and the template can be found at `site/app/Resources/FOSUserBundle/views/Resetting/check_email.html.twig`
3. The email that gets sent to the user with the token link can be found at `site/app/Resources/FOSUserBundle/views/Resetting/email.html.twig`
4. The link that you must follow on your email has an url of the form `/user/reset/$TOKEN$` and the template can be found at `site/app/Resources/FOSUserBundle/views/Resetting/reset.html.twig`

The default email template on step No 3 is still the default, i.e a very simple message. We should change this to something in proper English and possibly devise a common email template to also use for other email purposes like e.g registration (we currently don't send anything) as discussed in #142. I just saw that @agathver has already proposed that we use https://github.com/rodriguezcommaj/salted for the email templates so let's see what it can offer.

Last but not least I have disabled the default FOS user profile routes because the `user/profile/show` one is redundant (we already have a profile settings page) and more importantly it allows the user to access the `user/profile/edit` page where currently he/she can edit the username or email completely uncontrolled.