### PR TITLE
Add Chips4Makers blog to Planet LibreCores

### DIFF
--- a/planet/config.ini
+++ b/planet/config.ini
@@ -111,3 +111,5 @@ name = Kritik Bhimani
 [https://www.philipp-wagner.com/blog/categories/fossi/]
 name = Philipp Wagner
 
+[https://chips4makers.io/blog/feeds/all.atom.xml]
+Name = Chips4Makers


### PR DESCRIPTION
As I don't have setup for testing this change is untested.
