### PR TITLE
Improve project creation page

### DIFF
--- a/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/new.html.twig
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/new.html.twig
@@ -75,6 +75,11 @@ other information about your project automatically.</p>
           {% else %}
             {{ form_row(form.githubSourceRepo, {'label': 'Select a project from your GitHub account'}) }}
             {{ form_row(form.saveGithubSourceRepo) }}
+
+            <p><strong>Are you missing a repository from a GitHub organization you're member of?</strong>
+            Go to the <a href="https://github.com/settings/connections/applications" target="_blank">Authorized OAuth Apps</a> page in your GitHub settings, and click on"LibreCores".
+            There you can grant access to other organizations.
+            If you're done, refresh this page to see the organization repositories in the list.</p>
           {% endif %}
         {% else %}
           <p>We cannot import projects from your GitHub account because your

--- a/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/new.html.twig
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/new.html.twig
@@ -14,7 +14,7 @@ source code location of your project, we'll scan your source code and get all
 other information about your project automatically.</p>
 
 {{ form_start(form) }}
-  <div class="form-group">
+  <div class="form-group {{ form.displayName.vars.errors|length > 0 ? 'has-error' : '' }}">
     {{ form_label(form.displayName, "What's the name of your project?", {'label_attr': {'class': 'librecores-new-project-label'}}) }}
 
     {{ form_errors(form.displayName) }}
@@ -24,7 +24,7 @@ other information about your project automatically.</p>
     </div>
   </div>
 
-  <div class="form-group">
+  <div class="form-group {{ form.name.vars.errors|length > 0 ? 'has-error' : '' }}">
     {{ form_label(form.name, "Where would you like to find your project on LibreCores?", {'label_attr': {'class': 'librecores-new-project-label'}}) }}
 
     {{ form_errors(form.parentName) }}
@@ -110,7 +110,7 @@ other information about your project automatically.</p>
 
 {% block pagejs %}
 // propose a name from the displayName
-// The name does not follow all validation rules for simplicity, i.e. it's 
+// The name does not follow all validation rules for simplicity, i.e. it's
 // possible for a proposed name to fail validation.
 $('#{{ form.displayName.vars.id|e('js') }}')
   .keyup(function() {

--- a/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/new.html.twig
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/new.html.twig
@@ -46,17 +46,15 @@ other information about your project automatically.</p>
     <p>LibreCores scans the source code of your project and extracts things
     like the README or the license out of it.</p>
 
-    {{ form_errors(form.gitSourceRepoUrl) }}
-
     <ul class="nav nav-tabs">
-      <li role="presentation" class="{{ isGithubConnected ? 'active'}}">
+      <li role="presentation" class="{{ activeSourcePanel == 'github' ? 'active'}}">
         <a href="#github" aria-controls="settings" role="tab" data-toggle="tab">
           <i class="fa fa-github" aria-hidden="true"></i>
           GitHub
         </a>
       </li>
-      <li role="presentation" class="{{ not isGithubConnected ? 'active'}}">
-        <a href="#git" aria-controls="settings" role="tab" data-toggle="tab">
+      <li role="presentation" class="{{ activeSourcePanel == 'git_url' ? 'active'}}">
+        <a href="#git_url" aria-controls="settings" role="tab" data-toggle="tab">
           <i class="fa fa-git" aria-hidden="true"></i>
           Other Git repository
         </a>
@@ -69,7 +67,7 @@ other information about your project automatically.</p>
     </ul>
 
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane {{ isGithubConnected ? 'active'}}" id="github">
+      <div role="tabpanel" class="tab-pane {{ activeSourcePanel == 'github' ? 'active'}}" id="github">
         {% if isGithubConnected %}
           {% if noGithubRepos %}
             <p>You don't have access to any repository on GitHub (or haven't granted us access).
@@ -88,7 +86,7 @@ other information about your project automatically.</p>
       </div>
 
 
-      <div role="tabpanel" class="tab-pane {{ not isGithubConnected ? 'active'}}" id="git">
+      <div role="tabpanel" class="tab-pane {{ activeSourcePanel == 'git_url' ? 'active'}}" id="git_url">
         {{ form_row(form.gitSourceRepoUrl, {'label': 'Enter a Git repository URL', 'attr': {'style': 'width:500px', 'placeholder': 'URL, e.g. https://github.com/yourname/project'}}) }}
 
         {{ form_row(form.saveGitSourceRepoUrl) }}


### PR DESCRIPTION
This fixes three issues:
- Issue #201 : Validate the git URL form field. This validation is done in two steps:
  - Since this field is not mapped, we manually add constraints to the field.
  - Since there are two ways to add a repository, selected by the submit button, we need to enable a specific validation group based on which button is pressed.
- Add a note on organization repositories.
- Improve the form styling to make errors more visible.