### PR TITLE
Temporarily disable RISC-V news feed

### DIFF
--- a/planet/config.ini
+++ b/planet/config.ini
@@ -71,6 +71,9 @@ name = AB Open FOSSi Community News
 #[https://riscv.org/feed]
 #name = RISC-V News
 
+[https://riscv.org/category/Events/feed]
+name = RISC-V Events
+
 [https://www.sifive.com/feed.xml]
 name = SiFive
 

--- a/planet/config.ini
+++ b/planet/config.ini
@@ -68,8 +68,8 @@ name = Verification Gentleman
 [https://abopen.com/news/tag/fossi/feed/]
 name = AB Open FOSSi Community News
 
-[https://riscv.org/feed]
-name = RISC-V News
+#[https://riscv.org/feed]
+#name = RISC-V News
 
 [https://www.sifive.com/feed.xml]
 name = SiFive


### PR DESCRIPTION
This news feed has been too busy recently and the content was not very original but mostly PR related to RISC-V member companies. I think we should re-iterate on that again, but currently I don't see that much value for the LibreCores Planet Feed.