### PR TITLE
Resolving the overlapping of footer bug in project settings page

### DIFF
--- a/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/settings.html.twig
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/views/Project/settings.html.twig
@@ -123,6 +123,8 @@
       </div>
     </div>
   </div>
+</div>
+</div>
 {{ form_end(form) }}
 {% endblock %}
 


### PR DESCRIPTION
Resolving issue #223 
There were a bug in closing of `div` tag in project settings page. 