### PR TITLE
Add styling for search facets

### DIFF
--- a/site/web/assets/css/librecores.css
+++ b/site/web/assets/css/librecores.css
@@ -694,6 +694,22 @@ a.classifiation-tag:hover {
   background-color: #def;
 }
 
+div.facet-item {
+  margin: 0 0.5em 0.5em 0;
+  padding: 0.3em;
+  background-color: #f1f8ff;
+  text-decoration: none;
+  border-radius: 3px;
+  }
+
+  div.facet-item:hover {
+    margin: 0 0.5em 0.5em 0;
+    padding: 0.3em;
+    background-color: #def;
+    text-decoration: none;
+    border-radius: 3px;
+    }
+
 .search-type {
   text-align: left;
 }

--- a/site/web/assets/js/search.js
+++ b/site/web/assets/js/search.js
@@ -148,7 +148,7 @@ function algoliaInstantSearch(options, searchType) {
         separator: '::',
         templates: {
           header: '<h3>Classifications</h3>',
-          item:  '<a href="{{url}}" class="facet-item {{#isRefined}}active{{/isRefined}}"><span class="facet-name"> {{label}}</span class="facet-name"><span class="ais-hierarchical-menu--count">{{count}}</span></a>'
+          item:  '<div class="facet-item col-sm-12"><a href="{{url}}" class="facet-item {{#isRefined}}active{{/isRefined}}"><span class="facet-name"> {{label}}</span><span class="ais-hierarchical-menu--count">{{count}}</span></a></div>'
         },
       })
     );


### PR DESCRIPTION
Resolving Issue #271 

I wrapped individual items under the "Categories" header in rounded divs that change color when you mouse over them. This styling is similar to styling  used on links/buttons under the main search result (imphil/optimsoc  in the picture.)

![searchfacetstyle](https://user-images.githubusercontent.com/28114489/46714251-7ba57800-cc28-11e8-93a2-38974990bc3e.png)


I may be able to add some logic to check if a category has any sub-categories and render a '+' sign accordingly.

Let me know what you think.