### PR TITLE
Add note about Algolia API keys

### DIFF
--- a/ansible/secrets.dist/dev-vagrant.secrets.yml
+++ b/ansible/secrets.dist/dev-vagrant.secrets.yml
@@ -4,18 +4,21 @@
 site_github_app_id: "INSERT_OAUTH_ID_HERE"
 site_github_app_secret: "INSERT_OAUTH_SECRET_HERE"
 
-# Google OAuth secrets
-site_google_app_id: "INSERT_OAUTH_ID_HERE"
-site_google_app_secret: "INSERT_OAUTH_SECRET_HERE"
+# Google OAuth secrets (optional, will disable Google login)
+# Create a new google login project
+site_google_app_id: ~
+site_google_app_secret: ~
 
-# SMTP configuration for outbound transactional mail
-site_smtp_host: 'INSERT_SMTP_HOST_HERE'
-site_smtp_port: 'INSERT_SMTP_PORT_HERE'
+# SMTP configuration for outbound transactional mail (optional)
+# You can use your own email server, gmail SMTP or providers like Sendgrid
+site_smtp_host: ~
+site_smtp_port: 465
 site_smtp_encryption: 'ssl' # options: tls, ssl, login
-site_smtp_user: 'INSERT_SMTP_USER_HERE'
-site_smtp_password: 'INSERT_SMTP_PASSWORD_HERE'
+site_smtp_user: ~
+site_smtp_password: ~
 
 # Algolia
+# Sign Up with Algolia, create a community project and generate the API keys
 site_algolia_app_id: 'INSERT_ALGOLIA_APP_ID_HERE'
 site_algolia_api_key: 'INSERT_ALGOLIA_API_KEY_HERE'
 site_algolia_search_key: 'INSERT_ALGOLIA_SEARCH_KEY_HERE'

--- a/doc/src/devenv/quickstart.rst
+++ b/doc/src/devenv/quickstart.rst
@@ -30,10 +30,14 @@ First, copy the default secrets file as starting point:
 
   cp ansible/secrets.dist/dev-vagrant.secrets.yml ansible/secrets/dev-vagrant.secrets.yml
 
-Now you have two options:
+Open the ``ansible/secrets/dev-vagrant.secrets.yml`` and follow the instructions in there to get a custom API key for the various providers.
 
-- Either open the ``ansible/secrets/dev-vagrant.secrets.yml`` and follow the instructions in there to get a custom API key for the various providers, or
-- Leave the file as-is and therefore disable all third-party APIs. This is sufficient if you do not want to change the user-login process.
+At minimum, we require:
+
+- GitHub for repository crawling
+- Algolia for search
+
+You can disable algolia by setting ``NullEngine`` as suggested `in their documentation <https://www.algolia.com/doc/framework-integration/symfony/advanced/#other-engines>`_.
 
 Step 3: Set up the development environment
 ------------------------------------------


### PR DESCRIPTION
Recent changes have made Algolia and GitHub API keys mandatory for
development. Mention those changes in Quickstart