### PR TITLE
Fix count comparison in UserOrgNameValidator

### DIFF
--- a/site/phpunit.xml.dist
+++ b/site/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="app/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <testsuites>
         <testsuite name="Project Test Suite">

--- a/site/src/Librecores/ProjectRepoBundle/Repository/OrganizationRepository.php
+++ b/site/src/Librecores/ProjectRepoBundle/Repository/OrganizationRepository.php
@@ -85,4 +85,23 @@ class OrganizationRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * @param string $name
+     *
+     * @return int
+     *
+     * @throws NonUniqueResultException
+     */
+    public function countByNameIgnoreCase(string $name): int
+    {
+        $name = strtolower($name);
+
+        return (int) $this->createQueryBuilder('o')
+            ->select('COUNT(o.id)')
+            ->where('LOWER(o.name) = :name')
+            ->getQuery()
+            ->setParameter('name', $name)
+            ->getSingleScalarResult();
+    }
 }

--- a/site/src/Librecores/ProjectRepoBundle/Repository/UserRepository.php
+++ b/site/src/Librecores/ProjectRepoBundle/Repository/UserRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Librecores\ProjectRepoBundle\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Librecores\ProjectRepoBundle\Entity\User;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * UserRepository
+ *
+ * @author Amitosh Swain Mahapatra <amitosh.swain@gmail.com>
+ */
+class UserRepository extends ServiceEntityRepository
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+}

--- a/site/src/Librecores/ProjectRepoBundle/Resources/config/services.yml
+++ b/site/src/Librecores/ProjectRepoBundle/Resources/config/services.yml
@@ -69,13 +69,6 @@ services:
         arguments:
             - '@exercise_html_purifier.default'
 
-    Librecores\ProjectRepoBundle\Validator\Constraints\UserOrgNameValidator:
-        arguments:
-            - '@doctrine'
-            - '@router'
-        tags:
-            - { name: validator.constraint_validator }
-
     # User/auth management
     Librecores\ProjectRepoBundle\Doctrine\UserManager:
         arguments:

--- a/site/src/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidator.php
+++ b/site/src/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidator.php
@@ -149,11 +149,7 @@ class UserOrgNameValidator extends ConstraintValidator
 
         // Check the org name against existing usernames
         if ($type === "org") {
-            $q = 'SELECT COUNT(u.id) FROM LibrecoresProjectRepoBundle:User u '.
-                'WHERE u.usernameCanonical = :name';
-            $cntUser = $em->createQuery($q)
-                ->setParameter('name', $name)
-                ->getSingleScalarResult();
+            $cntUser = $em->getRepository('LibrecoresProjectRepoBundle:User')->count([ 'usernameCanonical' => $name ]);
             if ($cntUser !== 0) {
                 return true;
             }
@@ -161,12 +157,7 @@ class UserOrgNameValidator extends ConstraintValidator
 
         // Check the username against existing org names
         if ($type === "user") {
-            $q = 'SELECT COUNT(o.id) '.
-                'FROM LibrecoresProjectRepoBundle:Organization o '.
-                'WHERE LOWER(o.name) = :name';
-            $cntOrg = $em->createQuery($q)
-                ->setParameter('name', $name)
-                ->getSingleScalarResult();
+            $cntOrg = $em->getRepository('LibrecoresProjectRepoBundle:Organization')->count([ 'name' => $name ]);
             if ($cntOrg !== 0) {
                 return true;
             }

--- a/site/tests/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidatorTest.php
+++ b/site/tests/Librecores/ProjectRepoBundle/Validator/Constraints/UserOrgNameValidatorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Librecores\ProjectRepoBundle\Validator\Constraints;
+
+use Librecores\ProjectRepoBundle\Repository\OrganizationRepository;
+use Librecores\ProjectRepoBundle\Repository\UserRepository;
+use LibreCores\TestUtils\Generator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class UserOrgNameValidatorTest extends TestCase
+{
+    public function testValidateRejectsANameLessThan4Characters()
+    {
+        $mockRouter = $this->createMock(Router::class);
+        $mockUserRepository = $this->createMock(UserRepository::class);
+        $mockOrgRepository = $this->createMock(OrganizationRepository::class);
+
+        $validator = new UserOrgNameValidator($mockRouter, $mockUserRepository, $mockOrgRepository);
+
+        $constraint = new UserOrgName();
+
+        $name = Generator::randomString(1, 3);
+        /** @var ExecutionContextInterface $mockExecutionContext */
+        $mockExecutionContext = $this->createMockExecutionContext($constraint->messageTooShort);
+
+        $validator->initialize($mockExecutionContext);
+        $validator->validate($name, $constraint);
+    }
+
+    public function testValidateRejectsANameGreaterThan39Characters()
+    {
+        $mockRouter = $this->createMock(Router::class);
+        $mockUserRepository = $this->createMock(UserRepository::class);
+        $mockOrgRepository = $this->createMock(OrganizationRepository::class);
+
+        $validator = new UserOrgNameValidator($mockRouter, $mockUserRepository, $mockOrgRepository);
+
+        $constraint = new UserOrgName();
+
+        $name = Generator::randomString(40, 255);
+
+        /** @var ExecutionContextInterface $mockExecutionContext */
+        $mockExecutionContext = $this->createMockExecutionContext($constraint->messageTooLong);
+
+        $validator->initialize($mockExecutionContext);
+        $validator->validate($name, $constraint);
+    }
+
+    public function testValidateRejectsANameWithInvalidCharacters()
+    {
+        $mockRouter = $this->createMock(Router::class);
+        $mockUserRepository = $this->createMock(UserRepository::class);
+        $mockOrgRepository = $this->createMock(OrganizationRepository::class);
+
+        $validator = new UserOrgNameValidator($mockRouter, $mockUserRepository, $mockOrgRepository);
+
+        $constraint = new UserOrgName();
+
+        $name = '!nvalid$';
+
+        /** @var ExecutionContextInterface $mockExecutionContext */
+        $mockExecutionContext = $this->createMockExecutionContext($constraint->messageInvalidCharacters);
+
+        $validator->initialize($mockExecutionContext);
+        $validator->validate($name, $constraint);
+    }
+
+    public function testValidateRejectsAReservedName()
+    {
+        $mockRouter = $this->createMock(Router::class);
+        $mockUserRepository = $this->createMock(UserRepository::class);
+        $mockOrgRepository = $this->createMock(OrganizationRepository::class);
+
+        $validator = new UserOrgNameValidator($mockRouter, $mockUserRepository, $mockOrgRepository);
+
+        $constraint = new UserOrgName();
+
+        $choices = array_filter(UserOrgNameValidator::RESERVED_NAMES, function ($s) { return strlen($s) > 4; });
+        $name = $choices[random_int(0, count($choices) - 1)];
+
+        /** @var ExecutionContextInterface $mockExecutionContext */
+        $mockExecutionContext = $this->createMockExecutionContext($constraint->messageReservedName);
+
+        $validator->initialize($mockExecutionContext);
+        $validator->validate($name, $constraint);
+    }
+
+    public function testValidateRejectsExistingUsername()
+    {
+        $mockRouter = $this->createMock(Router::class);
+        $mockUserRepository = $this->createMock(UserRepository::class);
+        $mockOrgRepository = $this->createMock(OrganizationRepository::class);
+
+        $mockUserRepository->expects($this->once())->method('count')->willReturn(1);
+
+        $validator = new UserOrgNameValidator($mockRouter, $mockUserRepository, $mockOrgRepository);
+
+        $constraint = new UserOrgName();
+        $constraint->payload['type'] = 'org';
+
+        $name = Generator::randomString(4, 39);
+
+        /** @var ExecutionContextInterface $mockExecutionContext */
+        $mockExecutionContext = $this->createMockExecutionContext($constraint->messageUniqueName);
+
+        $validator->initialize($mockExecutionContext);
+        $validator->validate($name, $constraint);
+    }
+
+    public function testValidateRejectsExistingOrgName()
+    {
+        $mockRouter = $this->createMock(Router::class);
+        $mockUserRepository = $this->createMock(UserRepository::class);
+        $mockOrgRepository = $this->createMock(OrganizationRepository::class);
+
+        $mockOrgRepository->expects($this->once())->method('countByNameIgnoreCase')->willReturn(1);
+
+        $validator = new UserOrgNameValidator($mockRouter, $mockUserRepository, $mockOrgRepository);
+
+        $constraint = new UserOrgName();
+        $constraint->payload['type'] = 'user';
+
+        $name = Generator::randomString(4, 39);
+
+        /** @var ExecutionContextInterface $mockExecutionContext */
+        $mockExecutionContext = $this->createMockExecutionContext($constraint->messageUniqueName);
+
+        $validator->initialize($mockExecutionContext);
+        $validator->validate($name, $constraint);
+    }
+
+    private function createMockExecutionContext(string $expectedViolation)
+    {
+        $mock = $this->createMock(ExecutionContextInterface::class);
+        $mock->expects($this->once())->method('buildViolation')
+            ->with($expectedViolation)
+            ->willReturn($this->createMockConstraintViolationBuilderInterface());
+
+        return $mock;
+    }
+
+    private function createMockConstraintViolationBuilderInterface()
+    {
+        $mock = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $mock->method('setParameter')->willReturnSelf();
+
+        return $mock;
+    }
+}

--- a/site/tests/Librecores/TestUtils/Generator.php
+++ b/site/tests/Librecores/TestUtils/Generator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LibreCores\TestUtils;
+
+class Generator
+{
+    /**
+     * @param int $minLength
+     * @param int $maxLength
+     *
+     * @return string
+     *
+     * @throws \Exception
+     */
+    public static function randomString(int $minLength, int $maxLength)
+    {
+
+        $length = random_int($minLength, $maxLength);
+
+        $characters = '0123456789'.
+            'abcdefghijklmnopqrstuvwxyz'.
+            'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $string = $characters[random_int(10, strlen($characters) - 1)];
+
+        for ($i = 1; $i < $length; $i++) {
+            $string .= $characters[random_int(0, strlen($characters) - 1)];
+        }
+
+        return $string;
+    }
+}

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__.'/../app/autoload.php';
+require __DIR__.'/Librecores/TestUtils/Generator.php';


### PR DESCRIPTION
Changes introduced in b9f93b5 broke the non-strict comparison used `UserOrgNameValidator`.

Use EntityRepository::count for better abstraction of logic and to avoid a non-strict comparison in our code.

Fix #314 