### PR TITLE
Fix classification tree generation

### DIFF
--- a/site/src/Librecores/ProjectRepoBundle/Controller/ProjectController.php
+++ b/site/src/Librecores/ProjectRepoBundle/Controller/ProjectController.php
@@ -328,8 +328,7 @@ class ProjectController extends Controller
         foreach ($classificationCategories as $category) {
             $temp = [
                 "id" => $category->getId(),
-                "parentId" => $category->getParent() ?
-                    $category->getParent() : $category->getParent()->getId(),
+                "parentId" => $category->getParent() ? $category->getParent()->getId() : null,
                 "name" => $category->getName(),
             ];
             $classificationHierarchy[] = $temp;


### PR DESCRIPTION
Avoids Null Pointer Exception, which prevents classification tree from generating.

Fixes #318 