### PR TITLE
Devel: Update Vagrant dependency

### DIFF
--- a/bootstrap-dev.sh
+++ b/bootstrap-dev.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Version of vagrant we depend on
-VAGRANT_VERSION=2.2.0
+VAGRANT_VERSION=2.2.4
 
 
 # make sure we're in the top-level dir


### PR DESCRIPTION
There's no hard requirement for this Vagrant version except for it being
the latest one and best supported with current VirtualBox versions.