### PR TITLE
Ansible: Install frontend JS dependencies

### DIFF
--- a/ansible/roles/web/tasks/frontend-js.yml
+++ b/ansible/roles/web/tasks/frontend-js.yml
@@ -1,0 +1,27 @@
+- name: Add yarn repository key
+  apt_key:
+    url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    state: present
+
+- name: Add yarn repository
+  apt_repository:
+    repo: deb https://dl.yarnpkg.com/debian/ stable main
+    state: present
+
+- name: Add NodeSource repository key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
+- name: Add node.js repository from NodeSource
+  apt_repository:
+    repo: "deb https://deb.nodesource.com/node_{{ nodejs_major_version }}.x xenial main"
+    state: present
+
+- name: Install frontend packages
+  apt:
+    pkg:
+      - nodejs
+      - yarn
+    state: present
+    update_cache: yes

--- a/ansible/roles/web/tasks/main.yml
+++ b/ansible/roles/web/tasks/main.yml
@@ -3,6 +3,7 @@
 - include: nginx.yml
 - include: php.yml
 - include: rabbitmq.yml
+- include: frontend-js.yml
 - include: github-markup.yml
 - include: librecores-site.yml
 - include: repocrawler.yml

--- a/ansible/roles/web/vars/main.yml
+++ b/ansible/roles/web/vars/main.yml
@@ -28,3 +28,6 @@ php_extensions_pecl: []
 
 # PHP FPM socket (for web servers)
 php_fpm_sock: "/var/run/php/php{{ php_version }}-fpm.sock"
+
+# Major version of nodejs to be used
+nodejs_major_version: 10


### PR DESCRIPTION
Install yarn and nodejs as prerequisite to switch from assetic to
webpack encore and other frontend technologies.

@aquibbaig that should be enough to get you started with webpack encore; let me know if you need something else installed.