### PR TITLE
Deployment: Install PHP intl extension

### DIFF
--- a/ansible/roles/web/vars/main.yml
+++ b/ansible/roles/web/vars/main.yml
@@ -15,6 +15,7 @@ php_extensions_packaged:
   - bcmath
   - mbstring
   - zip
+  - intl
 
 # Development extensions installed through OS packages
 # Like php_extensions_packaged, but only available during development


### PR DESCRIPTION
Suggested by composer in the following message:

```
symfony/polyfill-intl-idn suggests installing ext-intl (For best performance)
```