### PR TITLE
Fix ansible deprecations

### DIFF
--- a/ansible/roles/web/tasks/librecores-site.yml
+++ b/ansible/roles/web/tasks/librecores-site.yml
@@ -140,9 +140,10 @@
 
 # Install librecores planet generator
 - name: Install extra packages for librecores-planet
-  apt:  pkg={{ item }} state=present
-  with_items:
-    - python-libxslt1
+  apt:
+    state: present
+    pkg:
+      - python-libxslt1
 
 - name: Update planet every 30 minutes through cronjob
   cron:

--- a/ansible/roles/web/tasks/php.yml
+++ b/ansible/roles/web/tasks/php.yml
@@ -19,7 +19,10 @@
 # OS packaged PHP extensions
 - name: Install packaged PHP extensions
   become: true
-  apt:  package=php{{php_version}}-{{ item }} state=present
+  apt:
+    package:
+        - php{{php_version}}-{{ item }}
+    state: present
   with_items: "{{ php_extensions_packaged }}"
 
 - name: Enable packaged PHP extensions for all SAPIs
@@ -31,7 +34,10 @@
 
 - name: Install packaged PHP extensions for development
   become: true
-  apt:  package=php{{php_version}}-{{ item }} state=present
+  apt:
+    package:
+        - php{{php_version}}-{{ item }}
+    state: present
   with_items: "{{ php_devel_extensions_packaged }}"
 
 - name: Enable packaged PHP extensions for development for all SAPIs

--- a/ansible/roles/web/tasks/system.yml
+++ b/ansible/roles/web/tasks/system.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install extra packages
-  apt:  pkg={{ item }} state=present
-  with_items:
-    - mcrypt
-    - letsencrypt
+  apt:
+    state: present
+    pkg:
+      - mcrypt
+      - letsencrypt


### PR DESCRIPTION
Switch to new syntax for `apt` module which now accepts a list of packages under `pkg`.

NOTE: The warning about `use_https` is a false-positive and hence is left as-is

Fixes #297 