### PR TITLE
Deployment: Fix RabbitMQ service management

### DIFF
--- a/ansible/roles/web/handlers/main.yml
+++ b/ansible/roles/web/handlers/main.yml
@@ -8,5 +8,5 @@
 - name: restart rabbitmq
   service: name=rabbitmq-server enabled=yes state=restarted
 
-- name: restart librecores-rabbitmq
-  service: name=librecores-rabbitmq enabled=yes state=restarted
+- name: restart librecores-rabbitmq.target
+  service: name=librecores-rabbitmq.target enabled=yes state=restarted

--- a/ansible/roles/web/tasks/librecores-site.yml
+++ b/ansible/roles/web/tasks/librecores-site.yml
@@ -125,20 +125,30 @@
     chdir: /var/www/lc/site
   when: env.SYMFONY_ENV == 'prod'
 
-- name: Add systemd service for RabbitMQ
+- name: Remove old systemd service
+  file:
+    path: /etc/systemd/system/librecores-rabbitmq.service
+    state: absent
+
+- name: Add systemd services for individual RabbitMQ consumers
   template:
-    src: librecores-rabbitmq.service.j2
-    dest: /etc/systemd/system/librecores-rabbitmq.service
+    src: lc-rmqc.service.j2
+    dest: /etc/systemd/system/lc-rmqc-{{ item.name }}.service
     owner: root
     group: root
     mode: 0644
-  notify: restart librecores-rabbitmq
+  with_items: "{{ rabbitmq_consumers }}"
 
-- name: reload systemd to pick up changes in Unit files
+- name: Add systemd target for all RabbitMQ consumers
+  template:
+    src: lc-rmqc.target.j2
+    dest: /etc/systemd/system/lc-rmqc.target
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Reload systemd to pick up changes in unit files
   command: systemctl daemon-reload
-
-- name: ensure librecores-rabbitmq is running (and enable it at boot)
-  service: name=librecores-rabbitmq state=started enabled=yes
 
 # run this last to ensure all deployment-created directories are covered
 - name: Ensure directory permissions of Symfony log and cache directories
@@ -153,9 +163,11 @@
 
 # The services need to pick up the code changes by being restarted.
 # Thanks to RabbitMQ we don't loose any messages in this case.
-- name: Restart RabbitMQ message handlers
-  command: /bin/true
-  notify: restart librecores-rabbitmq
+- name: Ensure RabbitMQ consumer services are restarted and enabled at boot
+  service:
+    name: lc-rmqc.target
+    state: restarted
+    enabled: yes
 
 # Install librecores planet generator
 - name: Install extra packages for librecores-planet

--- a/ansible/roles/web/templates/lc-rmqc.service.j2
+++ b/ansible/roles/web/templates/lc-rmqc.service.j2
@@ -1,5 +1,7 @@
 [Unit]
-Description=LibreCores RabbitMQ
+Description=LibreCores RabbitMQ consumer {{ item.name }}
+PartOf=lc-rmqc.target
+
 Requires=rabbitmq-server.service
 After=rabbitmq-server.service
 
@@ -20,9 +22,15 @@ PartOf=nfs-client.target
 
 [Service]
 EnvironmentFile=/var/www/lc/site/app/config/symfony-env.sh
-ExecStart=/usr/bin/php /var/www/lc/site/bin/console rabbitmq:consumer -vv -w -l 256 -m 250 update_project_info
+
+{% if item.type == 'single' %}
+ExecStart=/usr/bin/php /var/www/lc/site/bin/console rabbitmq:consumer -w {{ rabbitmq_consumer_options }} {{ item.name }}
+{% elif item.type == 'multiple' %}
+ExecStart=/usr/bin/php /var/www/lc/site/bin/console rabbitmq:multiple-consumer -w {{ rabbitmq_consumer_options }} {{ item.name }}
+{% endif %}
+
 Restart=always
 User={{ web_user }}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=lc-rmqc.target

--- a/ansible/roles/web/templates/lc-rmqc.target.j2
+++ b/ansible/roles/web/templates/lc-rmqc.target.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Manage all RabbitMQ consumers for LibreCores
+
+{% for consumer in rabbitmq_consumers %}
+Wants=lc-rmqc-{{ consumer.name }}.service
+{% endfor %}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/web/vars/main.yml
+++ b/ansible/roles/web/vars/main.yml
@@ -30,3 +30,18 @@ php_fpm_sock: "/var/run/php/php{{ php_version }}-fpm.sock"
 
 # Major version of nodejs to be used
 nodejs_major_version: 10
+
+# RabbitMQ consumers started as service (through the Symfony rabbitmq bundle)
+# Uses the rabbitmq:consumer/rabbitmq:multiple-consumer console commands.
+rabbitmq_consumers:
+  - name: update_project_info
+    type: single
+# TODO: Fix consumer, currently broken (unable to start)
+#  - name: update_github_metadata
+#    type: single
+  - name: notification
+    type: multiple
+
+# Options passed to the RabbitMQ consumer services
+# Consume 250 messages per run, allow up to 256 MB of memory for this process
+rabbitmq_consumer_options: -vv --memory-limit 256 --messages 250


### PR DESCRIPTION
We use one service for each RabbitMQ consumer handling various web
background jobs. For the new notification service to work, it actually
needs to be enabled. And it seems that the GitHub metadata crawler was
never enabled -- and it fact it breaks when enabled. Adding code to
enable it once the underlying bug has been fixed.

Fixes #392